### PR TITLE
Adds instagram verification

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,8 +142,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
 
-        versionCode 58
-        versionName "1.0.41"
+        versionCode 59
+        versionName "1.0.42"
         resValue "string", "build_config_package", "co.audius.app"
     }
     productFlavors {

--- a/ios/AudiusReactNative.xcodeproj/project.pbxproj
+++ b/ios/AudiusReactNative.xcodeproj/project.pbxproj
@@ -375,13 +375,13 @@
 				BUNDLE_ID_SUFFIX = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.34;
+				MARKETING_VERSION = 1.0.35;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -407,12 +407,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.34;
+				MARKETING_VERSION = 1.0.35;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -595,13 +595,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.34;
+				MARKETING_VERSION = 1.0.35;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -675,12 +675,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.34;
+				MARKETING_VERSION = 1.0.35;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/AudiusReactNative/Info.plist
+++ b/ios/AudiusReactNative/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>109</string>
+	<string>110</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/src/message.ts
+++ b/src/message.ts
@@ -20,6 +20,7 @@ import { getInitialDarkModePreference, getPrefersDarkModeChange } from './theme'
 import { track, screen, identify } from './utils/analytics'
 import { Identify, Track, Screen, AnalyticsMessage } from './types/analytics'
 import { checkConnectivity, Connectivity } from './utils/connectivity'
+import { Provider } from './store/oauth/reducer'
 
 let sentInitialTheme = false
 
@@ -59,7 +60,8 @@ export enum MessageType {
   PUSH_ROUTE = 'action/push-route',
 
   // OAuth
-  REQUEST_TWITTER_AUTH = 'request-twiter-auth',
+  REQUEST_TWITTER_AUTH = 'request-twitter-auth',
+  REQUEST_INSTAGRAM_AUTH = 'request-instagram-auth',
 
   // Lifecycle
   ENTER_FOREGROUND = 'action/enter-foreground',
@@ -177,7 +179,9 @@ export const handleMessage = async (
 
     // OAuth
     case MessageType.REQUEST_TWITTER_AUTH:
-      return dispatch(oauthActions.openPopup(message))
+      return dispatch(oauthActions.openPopup(message, Provider.TWITTER))
+    case MessageType.REQUEST_INSTAGRAM_AUTH:
+      return dispatch(oauthActions.openPopup(message, Provider.INSTAGRAM))
 
     // Lifecycle
     case MessageType.BACKEND_SETUP:

--- a/src/store/oauth/actions.ts
+++ b/src/store/oauth/actions.ts
@@ -1,4 +1,5 @@
 import { Message } from "../../message"
+import { Provider } from "./reducer"
 
 export const OPEN_POPUP = 'OAUTH/OPEN_POPUP'
 export const CLOSE_POPUP = 'OAUTH/CLOSE_POPUP'
@@ -6,6 +7,7 @@ export const CLOSE_POPUP = 'OAUTH/CLOSE_POPUP'
 type OpenPopupAction = {
   type: typeof OPEN_POPUP
   message: Message
+  provider: Provider
 }
 
 type ClosePopupAction = {
@@ -16,9 +18,10 @@ export type OAuthActions =
   OpenPopupAction |
   ClosePopupAction
 
-export const openPopup = (message: Message): OpenPopupAction => ({
+export const openPopup = (message: Message, provider: Provider): OpenPopupAction => ({
   type: OPEN_POPUP,
-  message
+  message,
+  provider
 })
 
 export const closePopup = (): ClosePopupAction => ({

--- a/src/store/oauth/reducer.ts
+++ b/src/store/oauth/reducer.ts
@@ -9,12 +9,19 @@ export type OAuthState = {
   // Incoming message id to reply back to with OAuth results
   messageId: string | null
   url: string | null
+  provider: Provider | null
+}
+
+export enum Provider {
+  TWITTER = 'TWITTER',
+  INSTAGRAM = 'INSTAGRAM'
 }
 
 const initialState: OAuthState = {
   isOpen: false,
   messageId: null,
-  url: null
+  url: null,
+  provider: null
 }
 
 const reducer = (
@@ -27,14 +34,16 @@ const reducer = (
         ...state,
         isOpen: true,
         messageId: action.message.id,
-        url: action.message.authURL
+        url: action.message.authURL,
+        provider: action.provider
       }
     case CLOSE_POPUP:
       return {
         ...state,
         isOpen: false,
         messageId: null,
-        url: null
+        url: null,
+        provider: null
       }
     default:
       return state

--- a/src/store/oauth/selectors.ts
+++ b/src/store/oauth/selectors.ts
@@ -5,3 +5,4 @@ const getBaseState = (state: AppState) => state.oauth
 export const getIsOpen = (state: AppState) => getBaseState(state).isOpen
 export const getUrl = (state: AppState) => getBaseState(state).url
 export const getMessageId = (state: AppState) => getBaseState(state).messageId
+export const getAuthProvider = (state: AppState) => getBaseState(state).provider


### PR DESCRIPTION
## Changes
Adds the instagram message to be checked for on handleMessage from the dapp to native layer.
Updates the oauth redux store to add a provider field to differentiate between twitter and instagram auth
Updates the OAuth component 
  * it now has logic for instagram polling
  * It sends an empty message back when the popup is closed -  so the client isn't stuck in the loading phase
  * Handles instagram message, passing the code back on success

## Testing
This was tested by running the local dapp and port forwarding to an android device.
The Instagram/Twitter popup window appeared and was able to close and send a message back. 
The actual login to twitter/instagram to retrieve the code was not tested because I was unable to set a redirect url in the dapp to be verified by server. 

Am planning on testing in test flight.