### PR TITLE
Add push notification reminder

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,8 +142,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
 
-        versionCode 60
-        versionName "1.0.43"
+        versionCode 61
+        versionName "1.0.44"
         resValue "string", "build_config_package", "co.audius.app"
     }
     productFlavors {

--- a/ios/AudiusReactNative.xcodeproj/project.pbxproj
+++ b/ios/AudiusReactNative.xcodeproj/project.pbxproj
@@ -375,13 +375,13 @@
 				BUNDLE_ID_SUFFIX = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -407,12 +407,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -595,13 +595,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -675,12 +675,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "AudiusReactNative/Audius Music.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 111;
+				CURRENT_PROJECT_VERSION = 112;
 				DEVELOPMENT_TEAM = LRFCG93S85;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.0.36;
+				MARKETING_VERSION = 1.0.37;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/AudiusReactNative/Info.plist
+++ b/ios/AudiusReactNative/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>111</string>
+	<string>112</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,6 +9,9 @@ project 'AudiusReactNative',
 'Prod.Release' => :release
 
 target 'AudiusReactNative' do
+  permissions_path = '../node_modules/react-native-permissions/ios'
+  pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications"
+
   # Pods for AudiusReactNative
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
   pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -102,6 +102,8 @@ PODS:
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
+  - Permission-Notifications (3.0.0):
+    - RNPermissions
   - PromisesObjC (1.2.8)
   - Protobuf (3.11.2)
   - RCTRequired (0.61.4)
@@ -336,6 +338,8 @@ PODS:
     - React
   - RNFS (2.16.2):
     - React
+  - RNPermissions (3.0.0):
+    - React-Core
   - RNReactNativeHapticFeedback (1.8.2):
     - React
   - Yoga (1.14.0)
@@ -351,6 +355,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - lottie-ios (from `../node_modules/lottie-ios`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
+  - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../node_modules/react-native/`)
@@ -386,6 +391,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNFS (from `../node_modules/react-native-fs`)
+  - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -426,6 +432,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/lottie-ios"
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
+  Permission-Notifications:
+    :path: "../node_modules/react-native-permissions/ios/Notifications"
   RCTRequired:
     :path: "../node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -490,6 +498,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/push-notification-ios"
   RNFS:
     :path: "../node_modules/react-native-fs"
+  RNPermissions:
+    :path: "../node_modules/react-native-permissions"
   RNReactNativeHapticFeedback:
     :path: "../node_modules/react-native-haptic-feedback"
   Yoga:
@@ -520,6 +530,7 @@ SPEC CHECKSUMS:
   lottie-ios: 496ac5cea1bbf1a7bd1f1f472f3232eb1b8d744b
   lottie-react-native: 2a1a82bb326ae51331a5520de0cf706733c6db69
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
+  Permission-Notifications: 4325073de6e418cfbbdd8d296822c419d8ddc7ef
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
   Protobuf: dd1aaea7140debfe4dd0683fb8ef208e527ae153
   RCTRequired: f3b3fb6f4723e8e52facb229d0c75fdc76773849
@@ -554,9 +565,10 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 8539fc80a0075fcc9c8e2dff84cd22dc5bf1dacf
   RNCPushNotificationIOS: 5403d137a49c55f0dc2273be8473873e934359cd
   RNFS: 0d4191b1052bef9ce70deff00a5b4169c62bbd9b
+  RNPermissions: 350964d19150b183796a88180fb7ec62a1e41422
   RNReactNativeHapticFeedback: e11a4da0ce174e9f88b03cbaf5d76d94633cdee2
   Yoga: ba3d99dbee6c15ea6bbe3783d1f0cb1ffb79af0f
 
-PODFILE CHECKSUM: 493d5ebe892c28afed3c686290b9363a4aa17bb5
+PODFILE CHECKSUM: 7a6c9ead687ab512552acd264e94332dc0f17a0f
 
 COCOAPODS: 1.8.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -6699,6 +6699,11 @@
       "resolved": "https://registry.npmjs.org/react-native-music-control/-/react-native-music-control-0.11.0.tgz",
       "integrity": "sha512-BArIw7kK9eL4mj5jk3RmBFVMmz5rlJmXxD9KHurXYvKae5smdW1UK7RNtZaDfX2vFrGIjnMxCr/o95aBJthCrw=="
     },
+    "react-native-permissions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.0.0.tgz",
+      "integrity": "sha512-zBvf+o3NhgKmBk1I06GzZXaDfc9SUyO4M5TMcaCF1pwG1h4sI+XAv3gWSbryl6WnaZQc1zA+g7SocSoYcpJN5g=="
+    },
     "react-native-push-notification": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/react-native-push-notification/-/react-native-push-notification-3.1.9.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-native-google-cast": "^3.2.2",
     "react-native-haptic-feedback": "^1.8.2",
     "react-native-music-control": "^0.11.0",
+    "react-native-permissions": "^3.0.0",
     "react-native-push-notification": "^3.1.9",
     "react-native-static-server": "^0.4.2",
     "react-native-version-number": "^0.3.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import WebView from 'react-native-webview'
 import PushNotifications from './notifications'
 import { setup as setupAnalytics } from './utils/analytics'
 import useConnectivity from './components/web/useConnectivity'
+import { incrementSessionCount } from './utils/useSessionCount'
+import NotificationReminder from './components/notification-reminder/NotificationReminder'
 
 const store = createStore(
   createRootReducer(),
@@ -22,6 +24,9 @@ const Airplay = Platform.select({
   ios: () => require('./components/audio/Airplay').default,
   android: () => () => null,
 })()
+
+// Increment the session count when the App.tsx code is first run
+incrementSessionCount()
 
 const App = () => {
   // Track the web view as a top-level ref so that any children can use it

--- a/src/components/notification-reminder/NotificationReminder.tsx
+++ b/src/components/notification-reminder/NotificationReminder.tsx
@@ -1,0 +1,59 @@
+import React, { RefObject, useCallback } from 'react'
+import { checkNotifications, RESULTS } from 'react-native-permissions'
+
+import { MessagePostingWebView } from '../../types/MessagePostingWebView'
+import { postMessage } from '../../utils/postMessage'
+import useSessionCount from '../../utils/useSessionCount'
+import { MessageType } from '../../message'
+
+const REMINDER_EVERY_N_SESSIONS = 10
+
+type OwnProps = {
+  webRef: RefObject<MessagePostingWebView>
+  isSignedIn: boolean
+}
+
+const NotificationReminder = ({ webRef, isSignedIn }: OwnProps) => {
+    
+  const remindUserToTurnOnNotifications = useCallback((count: number) => {
+    if (webRef.current && isSignedIn) {
+      checkNotifications().then(({status}) => {
+        switch (status) {
+          case RESULTS.UNAVAILABLE:
+            // Notifications are not available (on this device / in this context).
+            // Do nothing.
+            return
+          case RESULTS.LIMITED:
+            // Some subset of notification features are enabled, let the user be.
+            // Do nothing.
+            return
+          case RESULTS.GRANTED:
+            // The user already has given notifications permissions!
+            // Do nothing.
+            return
+          case RESULTS.BLOCKED:
+            // The user has explicitly blocked notifications.
+            // Don't be a jerk.
+            // Do nothing.
+            return
+          case RESULTS.DENIED:
+            // The permission has not been requested or has been denied but it still requestable
+            // Appeal to the user to enable notifications
+            postMessage(webRef.current, {
+              type: MessageType.ENABLE_PUSH_NOTIFICATIONS_REMINDER,
+              isAction: true
+            })
+        }
+      }).catch((error) => {
+        // Not sure what happened, but swallow the error. Not worth blocking on.
+        console.error(error)
+      })
+    }
+  }, [webRef, isSignedIn])
+
+  useSessionCount(remindUserToTurnOnNotifications, REMINDER_EVERY_N_SESSIONS)
+  // No UI component
+  return null
+}
+
+export default NotificationReminder

--- a/src/components/notification-reminder/NotificationReminder.tsx
+++ b/src/components/notification-reminder/NotificationReminder.tsx
@@ -13,10 +13,17 @@ type OwnProps = {
   isSignedIn: boolean
 }
 
-const NotificationReminder = ({ webRef, isSignedIn }: OwnProps) => {
+const NotificationReminderWrapper = ({ webRef, isSignedIn }: OwnProps) => {
+  if (isSignedIn) {
+    return <NotificationReminder webRef={webRef} />
+  }
+  return null
+}
+
+const NotificationReminder = ({ webRef }: { webRef: RefObject<MessagePostingWebView> }) => {
     
   const remindUserToTurnOnNotifications = useCallback((count: number) => {
-    if (webRef.current && isSignedIn) {
+    if (webRef.current) {
       checkNotifications().then(({status}) => {
         switch (status) {
           case RESULTS.UNAVAILABLE:
@@ -49,11 +56,11 @@ const NotificationReminder = ({ webRef, isSignedIn }: OwnProps) => {
         console.error(error)
       })
     }
-  }, [webRef, isSignedIn])
+  }, [webRef])
 
   useSessionCount(remindUserToTurnOnNotifications, REMINDER_EVERY_N_SESSIONS)
   // No UI component
   return null
 }
 
-export default NotificationReminder
+export default NotificationReminderWrapper

--- a/src/components/web/WebApp.tsx
+++ b/src/components/web/WebApp.tsx
@@ -23,12 +23,13 @@ import { Message, handleMessage, MessageType } from '../../message'
 import { WebViewMessage, WebViewNavigation } from 'react-native-webview/lib/WebViewTypes'
 import { AppState } from '../../store'
 import { getTrack, getIndex } from '../../store/audio/selectors'
-import { getIsOnFirstPage } from '../../store/lifecycle/selectors'
+import { getIsOnFirstPage, getIsSignedIn } from '../../store/lifecycle/selectors'
 import SplashScreen from '../splash-screen/SplashScreen'
 import { postMessage } from '../../utils/postMessage'
 import { MessagePostingWebView } from '../../types/MessagePostingWebView'
 import useAppState from '../../utils/useAppState'
 import useKeyboardListeners from '../../utils/useKeyboardListeners'
+import NotificationReminder from '../notification-reminder/NotificationReminder'
 
 const USE_LOCALHOST_APP = Config.USE_LOCALHOST_APP
 const LOCALHOST_APP_URL = 'http://localhost:3000/feed'
@@ -118,6 +119,7 @@ const WebApp = ({
   trackInfo,
   trackIndex,
   isOnFirstPage,
+  isSignedIn,
   state: { lifecycle: { dappLoaded } }
 }: Props) => {
   // Start the local static asset server
@@ -481,6 +483,9 @@ const WebApp = ({
         dappLoaded={dappLoaded}
         key={`splash-${splashKey}`}
       />
+      {
+        hasLoaded && <NotificationReminder isSignedIn={isSignedIn} webRef={webRef} />
+      }
     </>
   )
 }
@@ -501,7 +506,8 @@ const mapStateToProps = (state: AppState) => ({
   state,
   trackInfo: getTrack(state),
   trackIndex: getIndex(state),
-  isOnFirstPage: getIsOnFirstPage(state)
+  isOnFirstPage: getIsOnFirstPage(state),
+  isSignedIn: getIsSignedIn(state)
 })
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onMessage: (

--- a/src/message.ts
+++ b/src/message.ts
@@ -51,6 +51,7 @@ export enum MessageType {
   ENABLE_PUSH_NOTIFICATIONS = 'enable-push-notifications',
   DISABLE_PUSH_NOTIFICATIONS = 'disable-push-notifications',
   RESET_NOTIFICATIONS_BADGE_COUNT = 'reset-notifications-badge-count',
+  ENABLE_PUSH_NOTIFICATIONS_REMINDER = 'action/enable-push-notifications-reminder',
 
   // Haptics
   HAPTIC_FEEDBACK = 'haptic-feedback',
@@ -69,6 +70,7 @@ export enum MessageType {
   BACKEND_SETUP = 'backend-setup',
   REQUEST_NETWORK_CONNECTED = 'request-network-connected',
   IS_NETWORK_CONNECTED = 'is-network-connected',
+  SIGNED_IN = 'signed-in',
 
   KEYBOARD_VISIBLE = 'keyboard-visible',
   KEYBOARD_HIDDEN = 'keyboard-hidden',
@@ -190,6 +192,8 @@ export const handleMessage = async (
     // Lifecycle
     case MessageType.BACKEND_SETUP:
       return dispatch(lifecycleActions.backendLoaded())
+    case MessageType.SIGNED_IN:
+      return dispatch(lifecycleActions.signedIn())
     case MessageType.REQUEST_NETWORK_CONNECTED:
       const isConnected = checkConnectivity(Connectivity.netInfo)
       postMessage(JSON.stringify({

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -128,7 +128,7 @@ class PushNotifications {
     PushNotification.requestPermissions()
   }
 
-  checkPermission (callback: () => void) {
+  checkPermission (callback: (permissions: { alert: 0 | 1 }) => void) {
     return PushNotification.checkPermissions(callback)
   }
 

--- a/src/store/lifecycle/actions.ts
+++ b/src/store/lifecycle/actions.ts
@@ -2,6 +2,7 @@ export const BACKEND_LOADED = 'LIFECYCLE/BACKEND_LOADED'
 export const BACKEND_TEAR_DOWN = 'LIFECYCLE/BACKEND_TEAR_DOWN'
 export const ON_FIRST_PAGE = 'LIFECYCLE/ON_FIRST_PAGE'
 export const NOT_ON_FIRST_PAGE = 'LIFECYCLE/NOT_ON_FIRST_PAGE'
+export const SIGNED_IN = 'LIFECYCLE/SIGNED_IN'
 
 type BackendLoadedAction = {
   type: typeof BACKEND_LOADED
@@ -18,10 +19,15 @@ type NotOnFirstPageAction = {
   type: typeof NOT_ON_FIRST_PAGE
 }
 
+type SignedInAction = {
+  type: typeof SIGNED_IN
+}
+
 export type LifecycleActions = BackendLoadedAction 
   | BackendTearDownAction 
   | OnFirstPageAction
   | NotOnFirstPageAction
+  | SignedInAction
 
 export const backendLoaded = (): BackendLoadedAction => ({
   type: BACKEND_LOADED
@@ -37,4 +43,8 @@ export const onFirstPage = (): OnFirstPageAction => ({
 
 export const notOnFirstPage = (): NotOnFirstPageAction => ({
   type: NOT_ON_FIRST_PAGE
+})
+
+export const signedIn = (): SignedInAction => ({
+  type: SIGNED_IN
 })

--- a/src/store/lifecycle/reducer.ts
+++ b/src/store/lifecycle/reducer.ts
@@ -4,16 +4,19 @@ import {
   BACKEND_TEAR_DOWN,
   ON_FIRST_PAGE,
   NOT_ON_FIRST_PAGE,
+  SIGNED_IN,
 } from "./actions"
 
 export type LifecycleState = {
   dappLoaded: boolean,
-  onFirstPage: boolean
+  onFirstPage: boolean,
+  signedIn: boolean
 }
 
 const initialState = {
   dappLoaded: false,
-  onFirstPage: true
+  onFirstPage: true,
+  signedIn: false
 }
 
 const reducer = (
@@ -39,6 +42,11 @@ const reducer = (
         return {
           ...state,
           onFirstPage: false
+        }
+      case SIGNED_IN:
+        return {
+          ...state,
+          signedIn: true
         }
       default:
         return state

--- a/src/store/lifecycle/selectors.ts
+++ b/src/store/lifecycle/selectors.ts
@@ -3,3 +3,5 @@ import { AppState } from 'src/store'
 const getBaseState = (state: AppState) => state.lifecycle
 
 export const getIsOnFirstPage = (state: AppState) => getBaseState(state).onFirstPage
+
+export const getIsSignedIn = (state: AppState) => getBaseState(state).signedIn

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -18,3 +18,4 @@ export const handleWebAppLog = (level: LOG_LEVEL, message: string) => {
       console.error(formatted)
       break
   }
+}

--- a/src/utils/useSessionCount.ts
+++ b/src/utils/useSessionCount.ts
@@ -1,0 +1,42 @@
+import AsyncStorage from '@react-native-community/async-storage'
+import { useEffect } from 'react'
+
+const SESSION_COUNT_KEY = '@session-count'
+
+const getSessionCount = async () => {
+  const sessionCount = await AsyncStorage.getItem(SESSION_COUNT_KEY)
+  return sessionCount ? parseInt(sessionCount, 10) : null
+}
+
+export const incrementSessionCount = async () => {
+  const sessionCount = await getSessionCount()
+  if (sessionCount) {
+    await AsyncStorage.setItem(SESSION_COUNT_KEY, (sessionCount + 1).toString())
+  } else {
+    await AsyncStorage.setItem(SESSION_COUNT_KEY, (1).toString())
+  }
+}
+
+/**
+ * Invokes `callback` every `frequency` sessions
+ * @param callback
+ * @param frequency
+ * @param startAt which session to start at
+ */
+const useSessionCount = (
+  callback: (count?: number) => void,
+  frequency: number,
+  startAt: number = 1
+) => {
+  useEffect(() => {
+    const work = async () => {
+      const count = await getSessionCount()
+      if (count && count >= startAt && count % frequency === 0) {
+        callback(count)
+      }
+    }
+    work()
+  }, [callback])
+}
+
+export default useSessionCount


### PR DESCRIPTION
https://trello.com/c/vWEe1wwb/1693-reminder-to-turn-on-notifications

Add a drawer that shows up every 10 sessions to have a user turn on notifications if they've never been turned on or explicitly disabled. Also shows on native mobile sign in flow.

New tools:
- ReactNativePermissions library (our react native push notifications doesn't have a way to handle the notification state "unset but requestable" (see Results.DENIED) in the PR)
- Session counter
- Lifecycle state for signed in

Tests
- [x]  Install app → after sign in, shows drawer to enable notifs
- [x]  If drawer dismissed, quitting and opening the app 10 times shows the drawer
- [x]  If accepted, quitting and opening the app 10 times does not show the drawer
- [x]  If denied, quitting and opening the app 10 times does not show the drawer