### PR TITLE
[AUD-298] Flush segment events as they come in

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -16,7 +16,10 @@ export const setup = async () => {
       // Record screen views automatically!
       recordScreenViews: false,
       // Record certain application events automatically!
-      trackAppLifecycleEvents: true
+      trackAppLifecycleEvents: true,
+      // Always flush events (worse for battery, but the web-view is likely even worse)
+      // https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#flush
+      flushAt: 1
     })
     analyticsSetupStatus = 'ready'
     console.info('Analytics ready')


### PR DESCRIPTION
Closes https://linear.app/audius/issue/AUD-298/flush-react-native-analytics-on-sign-up-flow

The only programmatic way of doing it would be to give react native awareness of all the event names/types and maybe we want to do it at some point, but i think overkill to help us in the near term