### PR TITLE
[AUD-867] Fix external links

### DIFF
--- a/ios/AudiusReactNative.xcodeproj/project.pbxproj
+++ b/ios/AudiusReactNative.xcodeproj/project.pbxproj
@@ -412,7 +412,8 @@
 				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -444,7 +445,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 180;
 				DEVELOPMENT_TEAM = LRFCG93S85;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -634,7 +636,8 @@
 				CURRENT_PROJECT_VERSION = 180;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = LRFCG93S85;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -714,7 +717,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 180;
 				DEVELOPMENT_TEAM = LRFCG93S85;
-				EXCLUDED_ARCHS = arm64;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = AudiusReactNative/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/src/components/web/WebApp.tsx
+++ b/src/components/web/WebApp.tsx
@@ -50,7 +50,7 @@ const STATIC_PORT = Config.STATIC_SERVER_PORT || 3100
 export const URL_SCHEME = 'audius://'
 
 // Intercept localhost://, file:///, audius://, twitter embed, or recaptcha
-const URL_INTERCEPT_PATTERN = /^(http:\/\/localhost|file:\/\/\/|audius:\/\/|https:\/\/platform.twitter|https:\/\/www.google.com\/recaptcha\/.*|.*)/
+const URL_INTERCEPT_PATTERN = /^(http:\/\/localhost|file:\/\/\/|audius:\/\/|https:\/\/platform.twitter|https:\/\/www.google.com\/recaptcha\/.*)/
 const AUDIUS_SITE_PREFIX = /^(https|http):\/\/audius.co\//
 const AUDIUS_REDIRECT_SITE_PREFIX = /^(https|http):\/\/redirect.audius.co\/app-redirect\//
 const AUDIUS_PORT_INCLUDE_PATTERN = /(:3100|:3101)/


### PR DESCRIPTION
### Description
Noticed this while trying to repro some of the `Network Error` stuff we see on mobile. External links are not working correctly from within the app because this regex had a .* that snuck in.

Also modifies the Excluded Architectures to only be simulator builds

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally running app

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
