### PR TITLE
Remove tolowercase for url deep link

### DIFF
--- a/src/components/web/WebApp.tsx
+++ b/src/components/web/WebApp.tsx
@@ -288,7 +288,6 @@ const WebApp = ({
   const pushRoute = useCallback(
     (routeUrl: string) => {
       const trimmedRoute = `/${routeUrl
-        .toLowerCase()
         .replace(URL_SCHEME, '')
         .replace(AUDIUS_SITE_PREFIX, '')
         .replace(AUDIUS_REDIRECT_SITE_PREFIX, '')}`


### PR DESCRIPTION
I don't believe we need this, but it was added here:
https://github.com/AudiusProject/audius-mobile-client-old/commit/13cc6bbb04bbe4f0c9f41303a733cdf8155f81ee#diff-8f820c4f37cc3f8198a8145000b9d76e17d5fa1322550288d0e0a951a897892c

And i dont know why.

This currently breaks deep links to hash ids, e.g. audius.co/tracks/7eP5n

### Description

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
