### PR TITLE
Fix autoplay app crash bug

### DIFF
--- a/src/components/audio/Audio.tsx
+++ b/src/components/audio/Audio.tsx
@@ -365,7 +365,7 @@ const Audio = ({
       isCloseToEndOfQueue
     ) {
       postMessage(webRef.current, {
-        type: MessageType.QUEUE_AUTOPLAY,
+        type: MessageType.REQUEST_QUEUE_AUTOPLAY,
         genre: (track && track.genre) || undefined,
         trackId: (track && track.trackId) || undefined,
         isAction: true

--- a/src/components/audio/GoogleCast.tsx
+++ b/src/components/audio/GoogleCast.tsx
@@ -114,6 +114,7 @@ const Cast = ({
             postMessage(webRef.current, {
               type: MessageType.SYNC_PLAYER,
               isPlaying: false,
+              incrementCounter: false,
               isAction: true
             })
           }
@@ -123,6 +124,7 @@ const Cast = ({
             postMessage(webRef.current, {
               type: MessageType.SYNC_PLAYER,
               isPlaying: true,
+              incrementCounter: false,
               isAction: true
             })
           }

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -73,6 +73,7 @@ export enum MessageType {
   // Action dispatchers
   SYNC_QUEUE = 'action/sync-queue',
   SYNC_PLAYER = 'action/sync-player',
+  QUEUE_AUTOPLAY = 'action/queue-autoplay',
   PUSH_ROUTE = 'action/push-route',
   SCROLL_TO_TOP = 'action/scroll-to-top',
 

--- a/src/message/types.ts
+++ b/src/message/types.ts
@@ -73,7 +73,7 @@ export enum MessageType {
   // Action dispatchers
   SYNC_QUEUE = 'action/sync-queue',
   SYNC_PLAYER = 'action/sync-player',
-  QUEUE_AUTOPLAY = 'action/queue-autoplay',
+  REQUEST_QUEUE_AUTOPLAY = 'action/request-queue-autoplay',
   PUSH_ROUTE = 'action/push-route',
   SCROLL_TO_TOP = 'action/scroll-to-top',
 

--- a/src/store/audio/reducer.ts
+++ b/src/store/audio/reducer.ts
@@ -47,6 +47,7 @@ export type AudioState = {
   shuffle: boolean
   shuffleIndex: number
   shuffleOrder: number[]
+  queueAutoplay: boolean
 }
 
 const initialState: AudioState = {
@@ -57,7 +58,8 @@ const initialState: AudioState = {
   repeatMode: RepeatMode.OFF,
   shuffle: false,
   shuffleIndex: -1,
-  shuffleOrder: []
+  shuffleOrder: [],
+  queueAutoplay: true
 }
 
 const reducer = (
@@ -167,7 +169,8 @@ const reducer = (
         index: action.message.index,
         shuffle: action.message.shuffle,
         shuffleIndex: action.message.shuffleIndex,
-        shuffleOrder: action.message.shuffleOrder
+        shuffleOrder: action.message.shuffleOrder,
+        queueAutoplay: action.message.queueAutoplay
       }
     case SHUFFLE:
       return {
@@ -185,7 +188,8 @@ const reducer = (
         repeatMode: RepeatMode.OFF,
         shuffle: false,
         shuffleIndex: -1,
-        shuffleOrder: []
+        shuffleOrder: [],
+        queueAutoplay: true
       }
     default:
       return state

--- a/src/store/audio/selectors.ts
+++ b/src/store/audio/selectors.ts
@@ -20,3 +20,5 @@ export const getRepeatMode = (state: AppState) => getBaseState(state).repeatMode
 export const getIsShuffleOn = (state: AppState) => getBaseState(state).shuffle
 export const getShuffleIndex = (state: AppState) =>
   getBaseState(state).shuffleIndex
+export const getQueueAutoplay = (state: AppState) =>
+  getBaseState(state).queueAutoplay


### PR DESCRIPTION
### Description

App used to crash when on a lineup that has only one track. We were trying to pull the genre off a non-existent track, which caused an exception.

This PR also handles triggering autoplay from native mobile when close to end of lineup.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

iPhone and Android emulators

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
