### PR TITLE
Set version of okhttp to fix android 11 crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -228,6 +228,11 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
     implementation 'com.google.firebase:firebase-perf:19.0.5'
 
+    // Setting version of okhttp to temporarily fix android 11 crash
+    // This can be removed when react-native is upgraded to 0.66
+    // See https://stackoverflow.com/questions/67982247/react-native-app-crashes-on-android-11-on-launch-without-giving-error
+    implementation("com.squareup.okhttp3:okhttp:4.9.1")
+    implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.1")
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,8 +142,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
 
-        versionCode 147
-        versionName "1.0.109"
+        versionCode 151
+        versionName "1.0.110"
         resValue "string", "build_config_package", "co.audius.app"
     }
     productFlavors {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,8 +142,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
 
-        versionCode 151
-        versionName "1.0.110"
+        versionCode 153
+        versionName "1.0.113"
         resValue "string", "build_config_package", "co.audius.app"
     }
     productFlavors {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "29.0.2"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 30
         targetSdkVersion = 30


### PR DESCRIPTION
### Description

This PR fixes the instant crash on android 11 after upgrading to `targetSdk: 30`. The better fix would be to upgrade to react-native 0.66

It also bumps the android build to trigger a new CI run. NOTE: needed to bump to 151 because of other versions that got pushed as part of the auto incrementing build number work

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
