### PR TITLE
[AUD-1147] Build on every branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ commands:
           command: |
             cd android
             bundle exec fastlane incrementVersionCode package_name:<<parameters.bundle-id>> track:<<parameters.track>>
-            bundle exec fastlane incrementVersionName package_name:co.<<parameters.bundle-id>> track:<<parameters.track>>
+            bundle exec fastlane incrementVersionName package_name:<<parameters.bundle-id>> track:<<parameters.track>>
       - run:
           name: generating the release apk & bundle
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,13 @@ jobs:
           build-directory: 'build-mobile-staging'
           bundle-id: 'co.audius.audiusmusic.bounce'
           env: '.env.stage'
-      - upload-ios:
-          bundle-id: 'co.audius.audiusmusic.bounce'
+      - when:
+          condition:
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+          steps:
+            - upload-ios:
+                bundle-id: 'co.audius.audiusmusic.bounce'
 
   build-upload-production-ios:
     working_directory: ~/audius-mobile-client
@@ -267,8 +272,13 @@ jobs:
           build-directory: 'build-mobile-production'
           bundle-id: 'co.audius.audiusmusic'
           env: '.env.prod'
-      - upload-ios:
-          bundle-id: 'co.audius.audiusmusic'
+      - when:
+          condition:
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+          steps:
+            - upload-ios:
+                bundle-id: 'co.audius.audiusmusic'
 
   build-upload-staging-android:
     working_directory: ~/audius-mobile-client
@@ -282,8 +292,13 @@ jobs:
           bundle-id: 'co.audius.app.bounce'
           track: 'alpha'
           remote-directory: 'audius-mobile-staging'
-      - upload-android:
-          upload-type: 'bounce'
+      - when:
+          condition:
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+          steps:
+            - upload-android:
+                upload-type: 'bounce'
 
   build-upload-production-android:
     working_directory: ~/audius-mobile-client
@@ -297,8 +312,13 @@ jobs:
           bundle-id: 'co.audius.app'
           track: 'alpha'
           remote-directory: 'audius-mobile'
-      - upload-android:
-          upload-type: 'alpha'
+      - when:
+          condition:
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+          steps:
+            - upload-android:
+                upload-type: 'alpha'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,13 +252,8 @@ jobs:
           build-directory: 'build-mobile-staging'
           bundle-id: 'co.audius.audiusmusic.bounce'
           env: '.env.stage'
-      - when:
-          condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
-          steps:
-            - upload-ios:
-                bundle-id: 'co.audius.audiusmusic.bounce'
+      - upload-ios:
+          bundle-id: 'co.audius.audiusmusic.bounce'
 
   build-upload-production-ios:
     working_directory: ~/audius-mobile-client
@@ -272,13 +267,8 @@ jobs:
           build-directory: 'build-mobile-production'
           bundle-id: 'co.audius.audiusmusic'
           env: '.env.prod'
-      - when:
-          condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
-          steps:
-            - upload-ios:
-                bundle-id: 'co.audius.audiusmusic'
+      - upload-ios:
+          bundle-id: 'co.audius.audiusmusic'
 
   build-upload-staging-android:
     working_directory: ~/audius-mobile-client
@@ -292,13 +282,8 @@ jobs:
           bundle-id: 'co.audius.app.bounce'
           track: 'alpha'
           remote-directory: 'audius-mobile-staging'
-      - when:
-          condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
-          steps:
-            - upload-android:
-                upload-type: 'bounce'
+      - upload-android:
+          upload-type: 'bounce'
 
   build-upload-production-android:
     working_directory: ~/audius-mobile-client
@@ -312,13 +297,8 @@ jobs:
           bundle-id: 'co.audius.app'
           track: 'alpha'
           remote-directory: 'audius-mobile'
-      - when:
-          condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
-          steps:
-            - upload-android:
-                upload-type: 'bounce'
+      - upload-android:
+          upload-type: 'bounce'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,8 @@ jobs:
           env: '.env.stage'
       - when:
           condition:
-            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
           steps:
             - upload-ios:
                 bundle-id: 'co.audius.audiusmusic.bounce'
@@ -273,7 +274,8 @@ jobs:
           env: '.env.prod'
       - when:
           condition:
-            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
           steps:
             - upload-ios:
                 bundle-id: 'co.audius.audiusmusic'
@@ -283,7 +285,7 @@ jobs:
     docker:
       - image: circleci/android:api-30-node
     steps:
-      - build-android
+      - build-android:
           build-directory: 'build-mobile-staging'
           build-type: 'bundleBounceRelease'
           bundle-id: 'co.audius.app.bounce'
@@ -291,7 +293,8 @@ jobs:
           remote-directory: 'audius-mobile-staging'
       - when:
           condition:
-            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
           steps:
             - upload-android:
                 upload-type: 'bounce'
@@ -301,7 +304,7 @@ jobs:
     docker:
       - image: circleci/android:api-30-node
     steps:
-      - build-android
+      - build-android:
           build-directory: 'build-mobile-production'
           build-type: 'bundleRelease'
           bundle-id: 'co.audius.app'
@@ -309,7 +312,8 @@ jobs:
           remote-directory: 'audius-mobile'
       - when:
           condition:
-            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+            matches:
+              { pattern: '^release.*$', value: << pipeline.git.branch >> }
           steps:
             - upload-android:
                 upload-type: 'bounce'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ jobs:
           build-directory: 'build-mobile-staging'
           bundle-id: 'co.audius.audiusmusic.bounce'
           env: '.env.stage'
-      when:
+      - when:
           condition:
             matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
           steps:
@@ -271,7 +271,7 @@ jobs:
           build-directory: 'build-mobile-production'
           bundle-id: 'co.audius.audiusmusic'
           env: '.env.prod'
-      when:
+      - when:
           condition:
             matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
           steps:
@@ -289,7 +289,7 @@ jobs:
           bundle-id: 'co.audius.app.bounce'
           track: 'alpha'
           remote-directory: 'audius-mobile-staging'
-      when:
+      - when:
           condition:
             matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
           steps:
@@ -307,7 +307,7 @@ jobs:
           bundle-id: 'co.audius.app'
           track: 'alpha'
           remote-directory: 'audius-mobile'
-      when:
+      - when:
           condition:
             matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
           steps:
@@ -344,9 +344,9 @@ workflows:
       - build-upload-production-ios:
           context: Audius Mobile Client
           requires:
-            - build-web-app
+            - build-production-web-app
 
       - build-upload-production-android:
           context: Audius Mobile Client
           requires:
-            - build-web-app
+            - build-production-web-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ commands:
       upload-type:
         default: 'prod'
         type: string
+    steps:
       - run:
           name: Upload to Play Store
           command: cd android && bundle exec fastlane <<parameters.upload-type>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
 
   build-upload-staging-android:
     working_directory: ~/audius-mobile-client
+    resource_class: large
     docker:
       - image: circleci/android:api-30-node
     steps:
@@ -301,6 +302,7 @@ jobs:
 
   build-upload-production-android:
     working_directory: ~/audius-mobile-client
+    resource_class: large
     docker:
       - image: circleci/android:api-30-node
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ jobs:
           track: 'alpha'
           remote-directory: 'audius-mobile'
       - upload-android:
-          upload-type: 'bounce'
+          upload-type: 'alpha'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,177 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.2.0
 
+commands:
+  # Build the audius-client to be bundled with the mobile client
+  build-web-app:
+    parameters:
+      build-type:
+        default: 'mobile-prod'
+        type: string
+      build-directory:
+        default: 'build-mobile-production'
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: copy-audius-client
+          # client is copied outside of project to avoid npm install conflicts
+          command: cp -R ./node_modules/audius-client ../audius-client
+
+      - restore_cache:
+          keys:
+            - dependency-cache-{{ checksum "../audius-client/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - dependency-cache-
+      - run: cd ../audius-client && npm install
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "../audius-client/package.json" }}
+          paths:
+            - ../audius-client/node_modules
+
+      - run:
+          name: build
+          command: cd ../audius-client && npm run build:<<parameters.build-type>>
+      - persist_to_workspace:
+          root: ../
+          paths:
+            - audius-client/<<parameters.build-directory>>
+
+  # Build the ios app
+  build-ios:
+    parameters:
+      build-directory:
+        default: 'build-mobile-production'
+        type: string
+      bundle-id:
+        default: 'co.audius.audiusmusic'
+        type: string
+      env:
+        default: '.env.prod'
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Move Web App build
+          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/<<parameters.build-directory>>/* web-app/Web.bundle/build
+      - run:
+          name: update cocoapods
+          command: sudo gem install cocoapods
+      - run:
+          name: copy bundle
+          command: npm run bundle:ios
+      - run:
+          name: install pods
+          command: cd ios && pod install
+      - run:
+          name: update bundler
+          command: gem install bundler:1.17.3
+      - restore_cache:
+          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
+      - run: cd ios && (bundle check || bundle install --path vendor/bundle)
+      - save_cache:
+          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
+          paths:
+            - ios/vendor/bundle
+      - run:
+          name: update fastlane
+          command: cd ios && bundle update fastlane
+      - run:
+          name: fastlane build
+          command: cp <<parameters.env>> ios/ && cd ios && bundle exec fastlane build bundle_id:<<parameters.bundle-id>>
+      - store_artifacts:
+          path: output
+      - store_test_results:
+          path: output/scan
+
+  # Upload the ios app to the App Store
+  upload-ios:
+    parameters:
+      bundle-id:
+        default: 'co.audius.audiusmusic'
+        type: string
+    steps:
+      - run:
+          name: fastlane upload
+          command: cd ios && bundle exec fastlane upload bundle_id:<<parameters.bundle-id>>
+
+  # Build the android app
+  build-android:
+    parameters:
+      build-directory:
+        default: 'build-mobile-production'
+        type: string
+      build-type:
+        default: 'bundleRelease'
+        type: string
+      bundle-id:
+        default: 'co.audius.app'
+        type: string
+      track:
+        default: 'beta'
+        type: string
+      remote-directory:
+        default: 'audius-mobile'
+        type: string
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Move Web App build
+          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/<<parameters.build-directory>>/* web-app/Web.bundle/build
+      - run:
+          name: migrate support libraries for androidX packages
+          command: |
+            npm run jetifier
+      - run:
+          name: update bundler
+          command: gem install bundler:1.17.3
+      - restore_cache:
+          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
+      - run: cd android && (bundle check || bundle install --path vendor/bundle)
+      - save_cache:
+          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
+          paths:
+            - android/vendor/bundle
+      - run:
+          name: fetch app fastlane json config to upload to play store
+          command: |
+            echo "$FASTLANE_PLAYSTORE_JSON" > android/app/api.txt
+            base64 --decode android/app/api.txt > android/app/api.json
+      - run:
+          name: increment version code
+          command: |
+            cd android
+            bundle exec fastlane incrementVersionCode package_name:<<parameters.bundle-id>> track:<<parameters.track>>
+            bundle exec fastlane incrementVersionName package_name:co.<<parameters.bundle-id>> track:<<parameters.track>>
+      - run:
+          name: generating the release apk & bundle
+          command: |
+            echo "yes" | sdkmanager "platforms;android-30" && cd android && ./gradlew <<parameters.build-type>>
+      - run:
+          name: install-awscli
+          command: sudo pip install awscli
+      - run: aws s3 sync ~/audius-mobile-client/android/app/build/outputs s3://<<parameters.remote-directory>>/android --delete
+
+  # Upload the android app to the Google Play Store
+  upload-android:
+    parameters:
+      upload-type:
+        default: 'prod'
+        type: string
+      - run:
+          name: Upload to Play Store
+          command: cd android && bundle exec fastlane <<parameters.upload-type>>
+
 jobs:
   init:
-    working_directory: ~/react-native-wrapper
+    working_directory: ~/audius-mobile-client
     docker:
       - image: circleci/node:14.18
     steps:
@@ -51,268 +219,99 @@ jobs:
             - .env.stage
             - .env.prod
 
-  build-web-app:
-    working_directory: ~/react-native-wrapper
+  build-production-web-app:
+    working_directory: ~/audius-mobile-client
     docker:
       - image: circleci/node:14.18
     resource_class: large
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: copy-audius-client
-          # client is copied outside of project to avoid npm install conflicts
-          command: cp -R ./node_modules/audius-client ../audius-client
-
-      - restore_cache:
-          keys:
-            - dependency-cache-{{ checksum "../audius-client/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - dependency-cache-
-      - run: cd ../audius-client && npm install
-
-      - save_cache:
-          key: dependency-cache-{{ checksum "../audius-client/package.json" }}
-          paths:
-            - ../audius-client/node_modules
-
-      - run:
-          name: build-production-web-app
-          command: cd ../audius-client && npm run build:mobile-prod
-      - persist_to_workspace:
-          root: ../
-          paths:
-            - audius-client/build-mobile-production
+      - build-web-app:
+          build-type: 'mobile-prod'
+          build-directory: 'build-mobile-production'
 
   build-staging-web-app:
-    working_directory: ~/react-native-wrapper
+    working_directory: ~/audius-mobile-client
     docker:
       - image: circleci/node:14.18
     resource_class: large
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: copy-audius-client
-          # client is copied outside of project to avoid npm install conflicts
-          command: cp -R ./node_modules/audius-client ../audius-client
+      - build-web-app:
+          build-type: 'mobile-stage'
+          build-directory: 'build-mobile-staging'
 
-      - restore_cache:
-          keys:
-            - dependency-cache-{{ checksum "../audius-client/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - dependency-cache-
-      - run: cd ../audius-client && npm install
-
-      - save_cache:
-          key: dependency-cache-{{ checksum "../audius-client/package.json" }}
-          paths:
-            - ../audius-client/node_modules
-
-      - run:
-          name: build-staging-web-app
-          command: cd ../audius-client && npm run build:mobile-stage
-      - persist_to_workspace:
-          root: ../
-          paths:
-            - audius-client/build-mobile-staging
-
-  upload-staging-ios:
-    working_directory: ~/react-native-wrapper
+  build-upload-staging-ios:
+    working_directory: ~/audius-mobile-client
     macos: # Run on osx so app can be created and signed.
       xcode: '13.1.0'
     environment:
       FL_OUTPUT_DIR: output
-      FASTLANE_LANE: bounce
     shell: /bin/bash --login -o pipefail
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Move Staging build
-          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/build-mobile-staging/* web-app/Web.bundle/build
-      
-      - run:
-          name: update cocoapods
-          command: sudo gem install cocoapods
-      - run:
-          name: copy bundle
-          command: npm run bundle:ios
+      - build-ios:
+          build-directory: 'build-mobile-staging'
+          bundle-id: 'co.audius.audiusmusic.bounce'
+          env: '.env.stage'
+      when:
+          condition:
+            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+          steps:
+            - upload-ios:
+                bundle-id: 'co.audius.audiusmusic.bounce'
 
-      - run:
-          name: install pods
-          command: cd ios && pod install
-      - run:
-          name: update bundler
-          command: gem install bundler:1.17.3
-      - restore_cache:
-          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
-      - run: cd ios && (bundle check || bundle install --path vendor/bundle)
-      - save_cache:
-          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
-          paths:
-            - ios/vendor/bundle
-
-      - run:
-          name: update fastlane
-          command: cd ios && bundle update fastlane
-      - run:
-          name: fastlane
-          command: cp .env.stage ios/ && cd ios && bundle exec fastlane $FASTLANE_LANE
-      - store_artifacts:
-          path: output
-      - store_test_results:
-          path: output/scan
-
-  upload-ios:
-    working_directory: ~/react-native-wrapper
+  build-upload-production-ios:
+    working_directory: ~/audius-mobile-client
     macos: # Run on osx so app can be created and signed.
       xcode: '13.1.0'
     environment:
       FL_OUTPUT_DIR: output
-      FASTLANE_LANE: beta
     shell: /bin/bash --login -o pipefail
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Move production build
-          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/build-mobile-production/* web-app/Web.bundle/build
-      
-      - run:
-          name: update cocoapods
-          command: sudo gem install cocoapods
-      - run:
-          name: copy bundle
-          command: npm run bundle:ios
+      - build-ios:
+          build-directory: 'build-mobile-production'
+          bundle-id: 'co.audius.audiusmusic'
+          env: '.env.prod'
+      when:
+          condition:
+            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+          steps:
+            - upload-ios:
+                bundle-id: 'co.audius.audiusmusic'
 
-      - run:
-          name: install pods
-          command: cd ios && pod install
-      - run:
-          name: update bundler
-          command: gem install bundler:1.17.3
-      - restore_cache:
-          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
-      - run: cd ios && (bundle check || bundle install --path vendor/bundle)
-      - save_cache:
-          key: 1-gems-{{ checksum "ios/Gemfile.lock" }}
-          paths:
-            - ios/vendor/bundle
-
-      - run:
-          name: update fastlane
-          command: cd ios && bundle update fastlane
-      - run:
-          name: fastlane
-          command: cp .env.prod ios/ && cd ios && bundle exec fastlane $FASTLANE_LANE
-      - store_artifacts:
-          path: output
-      - store_test_results:
-          path: output/scan
-
-  upload-staging-android:
-    working_directory: ~/react-native-wrapper
+  build-upload-staging-android:
+    working_directory: ~/audius-mobile-client
     docker:
       - image: circleci/android:api-30-node
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      
-      - run:
-          name: Move Staging build
-          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/build-mobile-staging/* web-app/Web.bundle/build
-      - run:
-          name: migrate support libraries for androidX packages
-          command: |
-            npm run jetifier
-      - run:
-          name: update bundler
-          command: gem install bundler:1.17.3
-      - restore_cache:
-          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
-      - run: cd android && (bundle check || bundle install --path vendor/bundle)
-      - save_cache:
-          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
-          paths:
-            - android/vendor/bundle
-      - run:
-          name: fetch app fastlane json config to upload to play store
-          command: |
-            echo "$FASTLANE_PLAYSTORE_JSON" > android/app/api.txt
-            base64 --decode android/app/api.txt > android/app/api.json
-      - run:
-          name: increment version code
-          command: |
-            cd android
-            bundle exec fastlane incrementVersionCode package_name:co.audius.app.bounce track:alpha
-            bundle exec fastlane incrementVersionName package_name:co.audius.app.bounce track:alpha
-      - run:
-          name: generating the staging release apk & bundle
-          command: |
-            echo "yes" | sdkmanager "platforms;android-30" && cd android && ./gradlew bundleBounceRelease
-      - run:
-          name: install-awscli
-          command: sudo pip install awscli
-      - run: aws s3 sync ~/react-native-wrapper/android/app/build/outputs s3://audius-mobile-staging/android --delete
-      - run:
-          name: Upload to Play Store
-          command: cd android && bundle exec fastlane bounce
+      - build-android
+          build-directory: 'build-mobile-staging'
+          build-type: 'bundleBounceRelease'
+          bundle-id: 'co.audius.app.bounce'
+          track: 'alpha'
+          remote-directory: 'audius-mobile-staging'
+      when:
+          condition:
+            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+          steps:
+            - upload-android:
+                upload-type: 'bounce'
 
-  upload-android:
-    resource_class: large
-    working_directory: ~/react-native-wrapper
+  build-upload-production-android:
+    working_directory: ~/audius-mobile-client
     docker:
       - image: circleci/android:api-30-node
     steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      
-      - run:
-          name: Move production build
-          command: mkdir -p web-app/Web.bundle/build && mv ./audius-client/build-mobile-production/* web-app/Web.bundle/build
-      - run:
-          name: migrate support libraries for androidX packages
-          command: |
-            npm run jetifier
-      - run:
-          name: update bundler
-          command: gem install bundler:1.17.3
-      - restore_cache:
-          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
-      - run: cd android && (bundle check || bundle install --path vendor/bundle)
-      - save_cache:
-          key: 1-gems-{{ checksum "android/Gemfile.lock" }}
-          paths:
-            - android/vendor/bundle
-      - run:
-          name: fetch app fastlane json config to upload to play store
-          command: |
-            echo "$FASTLANE_PLAYSTORE_JSON" > android/app/api.txt
-            base64 --decode android/app/api.txt > android/app/api.json
-      - run:
-          name: increment version code
-          command: |
-            cd android
-            bundle exec fastlane incrementVersionCode package_name:co.audius.app track:alpha
-            bundle exec fastlane incrementVersionName package_name:co.audius.app track:alpha
-      - run:
-          name: generating the release apk & bundle
-          command: |
-            echo "yes" | sdkmanager "platforms;android-30" && cd android && ./gradlew bundleRelease
-      - run:
-          name: install-awscli
-          command: sudo pip install awscli
-      - run: aws s3 sync ~/react-native-wrapper/android/app/build/outputs s3://audius-mobile/android --delete
-      - run:
-          name: Upload to Play Store
-          command: cd android && bundle exec fastlane alpha
+      - build-android
+          build-directory: 'build-mobile-production'
+          build-type: 'bundleRelease'
+          bundle-id: 'co.audius.app'
+          track: 'alpha'
+          remote-directory: 'audius-mobile'
+      when:
+          condition:
+            matches: { pattern: "^release.*$", value: << pipeline.git.branch >> }
+          steps:
+            - upload-android:
+                upload-type: 'bounce'
 
 workflows:
   version: 2
@@ -321,50 +320,32 @@ workflows:
       - init:
           context: Audius Mobile Client
 
-      - build-web-app:
+      - build-production-web-app:
           context: Audius Mobile Client
           requires:
             - init
-          filters:
-            branches:
-              only: /(^release.*)$/
 
       - build-staging-web-app:
           context: Audius Mobile Client
           requires:
             - init
-          filters:
-            branches:
-              only: /(^release.*)$/
 
-      - upload-staging-ios:
+      - build-upload-staging-ios:
           context: Audius Mobile Client
           requires:
             - build-staging-web-app
-          filters:
-            branches:
-              only: /(^release.*)$/
 
-      - upload-staging-android:
+      - build-upload-staging-android:
           context: Audius Mobile Client
           requires:
             - build-staging-web-app
-          filters:
-            branches:
-              only: /(^release.*)$/
 
-      - upload-ios:
+      - build-upload-production-ios:
           context: Audius Mobile Client
           requires:
             - build-web-app
-          filters:
-            branches:
-              only: /(^release.*)$/
 
-      - upload-android:
+      - build-upload-production-android:
           context: Audius Mobile Client
           requires:
             - build-web-app
-          filters:
-            branches:
-              only: /(^release.*)$/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -148,7 +148,7 @@ android {
 
         // versionCode is automatically incremented in CI
         versionCode 1
-        versionName "1.0.113"
+        versionName "1.1.0"
         resValue "string", "build_config_package", "co.audius.app"
     }
     productFlavors {

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -104,8 +104,8 @@ platform :android do
         s[re, 1] = previousVersionNameString
         f = File.new(path, 'w')
         f.write(s)
+        f.close
       end
 
-      f.close
   end
 end

--- a/ios/AudiusReactNative/Info.plist
+++ b/ios/AudiusReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.95</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -44,7 +44,8 @@ platform :ios do
 
     match(
       type: "appstore",
-      readonly: is_ci
+      readonly: is_ci,
+      app_identifier: options[:bundle_id]
     )
 
     settings_to_override = {

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -34,7 +34,7 @@ platform :ios do
       environment = 'production'
       scheme = 'AudiusReactNative'
       configuration = 'Release'
-    else if options[:bundle_id] === 'co.audius.audiusmusic.bounce'
+    else
       appId = MY_STAGING_APP_ID
       provisioningProfile = MY_STAGING_PROFILE
       environment = 'staging'
@@ -132,7 +132,7 @@ platform :ios do
 
     if (options[:bundle_id] === 'co.audius.audiusmusic') 
       appleId = "1491270519"
-    else if options[:bundle_id] === 'co.audius.audiusmusic.bounce'
+    else
       appleId = "1510764836"
     end
    

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -25,22 +25,36 @@ platform :ios do
   before_all do
     setup_circle_ci
   end
-  desc "Push a new beta build to TestFlight"
-  lane :beta do
+  desc "Build the app"
+  lane :build do |options|
+
+    if options[:bundle_id] === 'co.audius.audiusmusic'  
+      appId = MY_APP_ID
+      provisioningProfile = MY_PROFILE
+      environment = 'production'
+      scheme = 'AudiusReactNative'
+      configuration = 'Release'
+    else if options[:bundle_id] === 'co.audius.audiusmusic.bounce'
+      appId = MY_STAGING_APP_ID
+      provisioningProfile = MY_STAGING_PROFILE
+      environment = 'staging'
+      scheme = 'Bounce'
+      configuration = 'Bounce.Release'
+    end
+
     match(
       type: "appstore",
       readonly: is_ci
     )
 
     settings_to_override = {
-      :BUNDLE_IDENTIFIER => MY_APP_ID,
-      :PROVISIONING_PROFILE_SPECIFIER => MY_PROFILE,
+      :BUNDLE_IDENTIFIER => appId,
+      :PROVISIONING_PROFILE_SPECIFIER => provisioningProfile,
       :DEVELOPMENT_TEAM => MY_TEAM
     }
 
     if ENV["IS_PRODUCTION"] == "true"
-      api_environment = "production"
-      ENV["ENVFILE"]=".env.#{api_environment}"
+      ENV["ENVFILE"]=".env.#{environment}"
       puts "IS_PRODUCTION: #{ENV['IS_PRODUCTION']}"
       puts "ENVFILE: #{ENV['ENVFILE']}"
     end
@@ -57,7 +71,7 @@ platform :ios do
 
     previousVersionNumber = Gem::Version.new previousVersionNumberString
     versionNumber = Gem::Version.new get_version_number_from_plist(
-      scheme: 'AudiusReactNative'
+      scheme: scheme
     )
 
     # If the version specified in project is greater than
@@ -72,12 +86,12 @@ platform :ios do
 
       increment_version_number_in_plist(
         version_number: versionNumber,
-        scheme: 'AudiusReactNative'
+        scheme: scheme
       )
 
       increment_version_number_in_xcodeproj(
         version_number: versionNumber,
-        scheme: 'AudiusReactNative'
+        scheme: scheme
       )
     end
 
@@ -90,7 +104,7 @@ platform :ios do
     app_store_connect_api_key
     increment_build_number(
       build_number: app_store_build_number(
-        app_identifier: "co.audius.audiusmusic",
+        app_identifier: options[:bundle_id],
         initial_build_number: 1,
         version: versionNumber.to_s,
         live: false
@@ -101,119 +115,35 @@ platform :ios do
     gym(
       workspace: "AudiusReactNative.xcworkspace",
       codesigning_identity: "iPhone Distribution",
-      scheme: "AudiusReactNative",
+      scheme: scheme,
+      configuration: configuration,
       xcargs: settings_to_override,
       export_method: "app-store",
       export_options: {
           provisioningProfiles: {
-              MY_APP_ID => MY_PROFILE
+              appId => provisioningProfile
           }
       }
     )
+  end
 
+  descr "Push a build to TestFlight"
+  lane :upload do
+
+    if (options[:bundle_id] === 'co.audius.audiusmusic') 
+      appleId = "1491270519"
+    else if options[:bundle_id] === 'co.audius.audiusmusic.bounce'
+      appleId = "1510764836"
+    end
+   
     # Upload to test flight
     pilot(
       skip_waiting_for_build_processing: true,
-      apple_id: "1491270519",
+      apple_id: appleId,
+      app_identifier: options[:bundle_id],
       # Don't actually distribute, just upload
       skip_submission: true
     )
   end
-  desc "Push a new bounce build to TestFlight"
-  lane :bounce do
-    match(
-      type: "appstore",
-      readonly: is_ci,
-      app_identifier: "co.audius.audiusmusic.bounce"
-    )
 
-    settings_to_override = {
-      :BUNDLE_IDENTIFIER => MY_STAGING_APP_ID,
-      :PROVISIONING_PROFILE_SPECIFIER => MY_STAGING_PROFILE,
-      :DEVELOPMENT_TEAM => MY_TEAM
-    }
-
-    if ENV["IS_PRODUCTION"] == "true"
-      api_environment = "staging"
-      ENV["ENVFILE"]=".env.#{api_environment}"
-      puts "IS_PRODUCTION: #{ENV['IS_PRODUCTION']}"
-      puts "ENVFILE: #{ENV['ENVFILE']}"
-    end
-
-    # Increment version
-
-    # Version number (e.g. 1.0.100) will be incremented by a patch version
-    # from the currently live version in the app store. If a higher version number
-    # is specified in Info.plist, that one will be used
-
-    previousVersionNumberString = get_app_store_version_number(
-      bundle_id: 'co.audius.audiusmusic'
-    )
-
-    previousVersionNumber = Gem::Version.new previousVersionNumberString
-    versionNumber = Gem::Version.new get_version_number_from_plist(
-      scheme: 'Bounce'
-    )
-
-    # If the version specified in project is greater than
-    # the previous version number, there is no need to modify version number in the project
-    if versionNumber <= previousVersionNumber
-      # Increment the patch version
-      # This is necessary because the same version number cannot be used twice on the app store
-      patchRegex = /\d+.\d+.(\d+)/
-      previousPatch = previousVersionNumberString[patchRegex, 1]
-      previousVersionNumberString[patchRegex, 1] = (previousPatch.to_i + 1).to_s
-      versionNumber = previousVersionNumberString
-
-      increment_version_number_in_plist(
-        version_number: versionNumber,
-        scheme: 'Bounce'
-      )
-
-      increment_version_number_in_xcodeproj(
-        version_number: versionNumber,
-        scheme: 'Bounce'
-      )
-    end
-
-    # Increment build
-
-    # Build number (e.g. 12) needs to be unique for the given version number
-    # Increment using the updated version number so that for each version number
-    # build numbers start at 1
-
-    app_store_connect_api_key
-    increment_build_number(
-      build_number: app_store_build_number(
-        app_identifier: "co.audius.audiusmusic.bounce",
-        initial_build_number: 1,
-        version: versionNumber.to_s,
-        live: false
-      ) + 1,
-    )
-
-    # Build ios
-    gym(
-      workspace: "AudiusReactNative.xcworkspace",
-      codesigning_identity: "iPhone Distribution",
-      scheme: "Bounce",
-      configuration: "Bounce.Release",
-      xcargs: settings_to_override,
-      export_method: "app-store",
-      export_options: {
-          provisioningProfiles: {
-              MY_STAGING_APP_ID => MY_STAGING_PROFILE
-          }
-      }
-    )
-
-    # Upload to test flight
-    pilot(
-      skip_waiting_for_build_processing: true,
-      apple_id: "1510764836",
-      app_identifier: "co.audius.audiusmusic.bounce",
-      # Don't actually distribute, just upload
-      skip_submission: true
-    )
-  end
 end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -129,7 +129,7 @@ platform :ios do
   end
 
   desc "Push a build to TestFlight"
-  lane :upload do
+  lane :upload do |options|
 
     if (options[:bundle_id] === 'co.audius.audiusmusic') 
       appleId = "1491270519"

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -133,8 +133,10 @@ platform :ios do
 
     if (options[:bundle_id] === 'co.audius.audiusmusic') 
       appleId = "1491270519"
+      ipa = './output/gym/Audius Music.ipa'
     else
       appleId = "1510764836"
+      ipa = './output/gym/Audius Bounce Music.ipa'
     end
    
     # Upload to test flight
@@ -142,6 +144,7 @@ platform :ios do
       skip_waiting_for_build_processing: true,
       apple_id: appleId,
       app_identifier: options[:bundle_id],
+      ipa: ipa,
       # Don't actually distribute, just upload
       skip_submission: true
     )

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -127,7 +127,7 @@ platform :ios do
     )
   end
 
-  descr "Push a build to TestFlight"
+  desc "Push a build to TestFlight"
   lane :upload do
 
     if (options[:bundle_id] === 'co.audius.audiusmusic') 


### PR DESCRIPTION
### Description

The upgrade to react-native 0.66 broke the CI build and it wasn't caught until a release branch was cut because of the new CI setup (only building/upload release branches).

This PR:
* Configures CI to build the app on every branch
* Restricts the upload step to `release` branches
* DRYs up the ci config
* Bumps both Android and iOS to `1.1.0` for consistency

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
