### PR TITLE
Remove unused async storage to fix android build

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -413,7 +413,7 @@ PODS:
     - React
   - rn-fetch-blob (0.12.0):
     - React-Core
-  - RNCAsyncStorage (1.15.14):
+  - RNCAsyncStorage (1.12.1):
     - React-Core
   - RNCMaskedView (0.2.6):
     - React-Core
@@ -494,7 +494,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNFS (from `../node_modules/react-native-fs`)
@@ -622,7 +622,7 @@ EXTERNAL SOURCES:
   rn-fetch-blob:
     :path: "../node_modules/rn-fetch-blob"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-async-storage/async-storage"
+    :path: "../node_modules/@react-native-community/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNCPushNotificationIOS:
@@ -710,7 +710,7 @@ SPEC CHECKSUMS:
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
   ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNCAsyncStorage: 4b6538222ce3f01f61011f512226ba3aaa0dc336
+  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
   RNCMaskedView: d367b2a8df3992114e31b32b091a0c00dc800827
   RNCPushNotificationIOS: 089da3b657e1e3d464f38195fd2e3069608ef5af
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
@@ -726,4 +726,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 6df3068b227294b24a0ed6fcf9f6fb0cf19589af
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -413,7 +413,7 @@ PODS:
     - React
   - rn-fetch-blob (0.12.0):
     - React-Core
-  - RNCAsyncStorage (1.12.1):
+  - RNCAsyncStorage (1.15.14):
     - React-Core
   - RNCMaskedView (0.2.6):
     - React-Core
@@ -494,7 +494,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeDarkMode (from `../node_modules/react-native-dark-mode`)
   - rn-fetch-blob (from `../node_modules/rn-fetch-blob`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNFS (from `../node_modules/react-native-fs`)
@@ -622,7 +622,7 @@ EXTERNAL SOURCES:
   rn-fetch-blob:
     :path: "../node_modules/rn-fetch-blob"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-masked-view/masked-view"
   RNCPushNotificationIOS:
@@ -710,7 +710,7 @@ SPEC CHECKSUMS:
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
   ReactNativeDarkMode: 0178ffca3b10f6a7c9f49d6f9810232b328fa949
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
-  RNCAsyncStorage: cb9a623793918c6699586281f0b51cbc38f046f9
+  RNCAsyncStorage: 4b6538222ce3f01f61011f512226ba3aaa0dc336
   RNCMaskedView: d367b2a8df3992114e31b32b091a0c00dc800827
   RNCPushNotificationIOS: 089da3b657e1e3d464f38195fd2e3069608ef5af
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.37",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.37.tgz",
-      "integrity": "sha512-f8wJI1YAVKEYksgijSfuWVqiPrXZ5EP1ditZUkyXT8GK9425p/7tFE4E0YCsxobYdPUY8xMd1zBllLeihHrqdg==",
+      "version": "1.2.38",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.38.tgz",
+      "integrity": "sha512-Tl4df/jyXTu4e5Rw6+Uf41JWQfuqiL5MHyLMWDTv7rB9E0koJuzTEajqELfay5Pm2gxXkBKXn2LrXgr5YaZ3/w==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.1.1",
@@ -109,7 +109,7 @@
         "form-data": "3.0.0",
         "jsonschema": "1.2.6",
         "keccak256": "1.0.2",
-        "lodash": "4.17.15",
+        "lodash": "^4.17.15",
         "node-localstorage": "1.3.1",
         "proper-url-join": "1.2.0",
         "secp256k1": "4.0.2",
@@ -138,11 +138,6 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
@@ -5661,14 +5656,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@react-native-async-storage/async-storage": {
-      "version": "1.15.14",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz",
-      "integrity": "sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==",
-      "requires": {
-        "merge-options": "^3.0.4"
-      }
-    },
     "@react-native-community/async-storage": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.1.tgz",
@@ -9020,10 +9007,10 @@
       }
     },
     "audius-client": {
-      "version": "github:AudiusProject/audius-client#2bd0f8c8fbb79f318487d8c748f709200fc8546e",
-      "from": "github:AudiusProject/audius-client#2bd0f8c8fbb79f318487d8c748f709200fc8546e",
+      "version": "github:AudiusProject/audius-client#6e5fe2574b2b13568f2dd0ab6a4f3a14299fe703",
+      "from": "github:AudiusProject/audius-client#6e5fe2574b2b13568f2dd0ab6a4f3a14299fe703",
       "requires": {
-        "@audius/libs": "1.2.37",
+        "@audius/libs": "1.2.38",
         "@audius/stems": "0.3.18",
         "@craco/craco": "6.4.2",
         "@hcaptcha/react-hcaptcha": "0.3.6",
@@ -9130,6 +9117,11 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
+        "core-js": {
+          "version": "3.20.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.0.tgz",
+          "integrity": "sha512-KjbKU7UEfg4YPpskMtMXPhUKn7m/1OdTHTVjy09ScR2LVaoUXe8Jh0UdvN2EKUR6iKTJph52SJP95mAB0MnVLQ=="
+        },
         "fxa-common-password-list": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.2.tgz",
@@ -9187,6 +9179,28 @@
           "version": "2.13.8",
           "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
           "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+        },
+        "simplebar": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+          "requires": {
+            "can-use-dom": "^0.1.0",
+            "core-js": "^3.0.1",
+            "lodash.debounce": "^4.0.8",
+            "lodash.memoize": "^4.1.2",
+            "lodash.throttle": "^4.1.1",
+            "resize-observer-polyfill": "^1.5.1"
+          }
+        },
+        "simplebar-react-legacy": {
+          "version": "npm:simplebar-react@1.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+          "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+          "requires": {
+            "prop-types": "^15.6.1",
+            "simplebar": "^4.2.3"
+          }
         }
       }
     },
@@ -22289,21 +22303,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
-    "merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "requires": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        }
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -26281,9 +26280,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
-          "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.1.tgz",
+          "integrity": "sha512-NXKvBVUzIbs6ylBwmOwHFkZS2EXCcjnqr8ZCRNaXBkHAf+3mn/rPcJxwrzuc6movh8fxQAsUUfYklJ/EG+hZqQ=="
         }
       }
     },
@@ -31961,35 +31960,6 @@
       "requires": {
         "prop-types": "^15.6.1",
         "simplebar": "^5.1.0"
-      }
-    },
-    "simplebar-react-legacy": {
-      "version": "npm:simplebar-react@1.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
-      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-      "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^4.2.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.20.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.0.tgz",
-          "integrity": "sha512-KjbKU7UEfg4YPpskMtMXPhUKn7m/1OdTHTVjy09ScR2LVaoUXe8Jh0UdvN2EKUR6iKTJph52SJP95mAB0MnVLQ=="
-        },
-        "simplebar": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
-          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-          "requires": {
-            "can-use-dom": "^0.1.0",
-            "core-js": "^3.0.1",
-            "lodash.debounce": "^4.0.8",
-            "lodash.memoize": "^4.1.2",
-            "lodash.throttle": "^4.1.1",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        }
       }
     },
     "sisteransi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5656,12 +5656,12 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@react-native-community/async-storage": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/async-storage/-/async-storage-1.12.1.tgz",
-      "integrity": "sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==",
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.14",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz",
+      "integrity": "sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==",
       "requires": {
-        "deep-assign": "^3.0.0"
+        "merge-options": "^3.0.4"
       }
     },
     "@react-native-community/cli-debugger-ui": {
@@ -12927,14 +12927,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
       "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s="
-    },
-    "deep-assign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
-      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -22302,6 +22294,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@gorhom/portal": "1.0.9",
     "@hcaptcha/react-native-hcaptcha": "1.3.4",
     "@optimizely/react-sdk": "2.7.0",
-    "@react-native-community/async-storage": "1.12.1",
+    "@react-native-async-storage/async-storage": "1.15.14",
     "@react-native-community/netinfo": "5.9.10",
     "@react-native-community/push-notification-ios": "1.10.1",
     "@react-native-masked-view/masked-view": "0.2.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@gorhom/portal": "1.0.9",
     "@hcaptcha/react-native-hcaptcha": "1.3.4",
     "@optimizely/react-sdk": "2.7.0",
-    "@react-native-async-storage/async-storage": "1.15.14",
     "@react-native-community/async-storage": "1.12.1",
     "@react-native-community/netinfo": "5.9.10",
     "@react-native-community/push-notification-ios": "1.10.1",

--- a/src/components/web/WebApp.tsx
+++ b/src/components/web/WebApp.tsx
@@ -7,7 +7,7 @@ import React, {
   useContext
 } from 'react'
 
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import {
   Platform,
   NativeSyntheticEvent,

--- a/src/hooks/useRemoteConfig.ts
+++ b/src/hooks/useRemoteConfig.ts
@@ -36,7 +36,7 @@ export const useFeatureFlage = (flag: FeatureFlags) => {
   const isEnabled = useMemo(
     () => remoteConfigInstance.getFeatureEnabled(flag),
     // We want configLoaded and shouldRecompute to trigger refreshes of the memo
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [flag, configLoaded, shouldRecompute]
   )
   return { isLoaded: configLoaded, isEnabled }
@@ -51,7 +51,7 @@ export function useRemoteVar(
 ): boolean | string | number | null {
   const configLoaded = useSelector(isRemoteConfigLoaded)
   // eslint complains about configLoaded as part of the deps array
-  // eslint-disable-next-line
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const remoteVar = useMemo(() => remoteConfigInstance.getRemoteVar(key), [
     key,
     configLoaded,

--- a/src/hooks/useSessionCount.ts
+++ b/src/hooks/useSessionCount.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const SESSION_COUNT_KEY = '@session-count'
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,6 +1,6 @@
 import { RefObject } from 'react'
 
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform, PushNotificationPermissions } from 'react-native'
 import Config from 'react-native-config'
 // https://dev.to/edmondso006/react-native-local-ios-and-android-notifications-2c58

--- a/src/services/remote-config/remote-config-instance.ts
+++ b/src/services/remote-config/remote-config-instance.ts
@@ -1,5 +1,5 @@
 import * as optimizely from '@optimizely/react-sdk'
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { remoteConfig } from 'audius-client/src/common/services/remote-config'
 import Config from 'react-native-config'
 

--- a/src/store/search/hooks.ts
+++ b/src/store/search/hooks.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import AsyncStorage from '@react-native-community/async-storage'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { useSelector, useDispatch } from 'react-redux'
 
 import * as searchActions from './actions'


### PR DESCRIPTION
### Description

`@react-native-community/async-storage` has been superceded by `react-native-async-storage/async-storage` as the maintainers have changed. The upgrade was 3 minor versions to use the same version with compatibility with optimizely's sdk.

I went thru all the release notes & checked our API uses and everything should work -- no breaking changes to any of the methods we touch, and the methods look 1-1.
https://github.com/react-native-async-storage/async-storage/releases?page=4

Since this repo was a fork of the other, it uses the same storage paradigm, so we don't run the risk of losing any storage either.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Builds

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
