### PR TITLE
[AUD-1037]Get filename from client instead of generating it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10509,6 +10509,11 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
+        "core-js": {
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag=="
+        },
         "fxa-common-password-list": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.2.tgz",
@@ -10561,6 +10566,28 @@
           "version": "2.13.8",
           "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
           "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+        },
+        "simplebar": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+          "requires": {
+            "can-use-dom": "^0.1.0",
+            "core-js": "^3.0.1",
+            "lodash.debounce": "^4.0.8",
+            "lodash.memoize": "^4.1.2",
+            "lodash.throttle": "^4.1.1",
+            "resize-observer-polyfill": "^1.5.1"
+          }
+        },
+        "simplebar-react-legacy": {
+          "version": "npm:simplebar-react@1.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+          "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+          "requires": {
+            "prop-types": "^15.6.1",
+            "simplebar": "^4.2.3"
+          }
         }
       }
     },
@@ -33256,35 +33283,6 @@
       "requires": {
         "prop-types": "^15.6.1",
         "simplebar": "^5.1.0"
-      }
-    },
-    "simplebar-react-legacy": {
-      "version": "npm:simplebar-react@1.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
-      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-      "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^4.2.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.20.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
-          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag=="
-        },
-        "simplebar": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
-          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-          "requires": {
-            "can-use-dom": "^0.1.0",
-            "core-js": "^3.0.1",
-            "lodash.debounce": "^4.0.8",
-            "lodash.memoize": "^4.1.2",
-            "lodash.throttle": "^4.1.1",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        }
       }
     },
     "sisteransi": {

--- a/src/message/handlers/download.ts
+++ b/src/message/handlers/download.ts
@@ -22,11 +22,11 @@ const cancelDownloadTask = () => {
 export const messageHandlers: Partial<MessageHandlers> = {
   [MessageType.DOWNLOAD_TRACK]: async ({ message }) => {
     const fileUrl = message.urls.find(url => url !== null && url !== undefined)
-    const fileExtension = fileUrl.split('.').pop()
-    const fileName = message.title + '.' + fileExtension
+    const fileName = message.filename
+    const trackName = fileName.split('.').slice(0, -1).join('')
 
     dispatch(setVisibility({ drawer: 'DownloadTrackProgress', visible: true }))
-    dispatch(setFileInfo({ trackName: message.title, fileName: fileName }))
+    dispatch(setFileInfo({ trackName, fileName }))
     dispatch(setFetchCancel(cancelDownloadTask))
 
     if (Platform.OS === 'ios') {
@@ -66,8 +66,8 @@ export const messageHandlers: Partial<MessageHandlers> = {
             useDownloadManager: true,
             notification: true,
             mediaScannable: true,
-            title: message.title + 'download successful!',
-            description: message.title,
+            title: trackName + 'download successful!',
+            description: trackName,
             path: filePath,
             mime: 'audio/mpeg'
           }


### PR DESCRIPTION
### Description
QOL fix, get passed the filename instead of trying to generate it. (Filename is more important than track title, title may not exist in the case of stems)

### Dragons

### How Has This Been Tested?
Tested on iOS simulator, iOS Device, android Device

### How will this change be monitored?
