### PR TITLE
[AUD-1212] Upgrade react-native types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8699,11 +8699,10 @@
       }
     },
     "@types/react-native": {
-      "version": "0.60.31",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.60.31.tgz",
-      "integrity": "sha512-Y0Q+nv50KHnLL+jM0UH68gQQv7Wt6v2KuNepiHKwK1DoWGVd1oYun/GJCnvUje+/V8pMQQWW6QuBvHZz1pV7tQ==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.66.3.tgz",
+      "integrity": "sha512-ZJmd4R36dPmgm5I0lEcR/1wCPH31Lwqz2ApDmvNXPow2ssoF5EO7NlNMG6hsROBbzYSf5U0DPVDAyW39VzvuAA==",
       "requires": {
-        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },
@@ -10495,6 +10494,11 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
+        "core-js": {
+          "version": "3.20.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
+          "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
+        },
         "fxa-common-password-list": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.2.tgz",
@@ -10547,6 +10551,28 @@
           "version": "2.13.8",
           "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
           "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+        },
+        "simplebar": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+          "requires": {
+            "can-use-dom": "^0.1.0",
+            "core-js": "^3.0.1",
+            "lodash.debounce": "^4.0.8",
+            "lodash.memoize": "^4.1.2",
+            "lodash.throttle": "^4.1.1",
+            "resize-observer-polyfill": "^1.5.1"
+          }
+        },
+        "simplebar-react-legacy": {
+          "version": "npm:simplebar-react@1.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+          "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+          "requires": {
+            "prop-types": "^15.6.1",
+            "simplebar": "^4.2.3"
+          }
         }
       }
     },
@@ -33310,35 +33336,6 @@
       "requires": {
         "prop-types": "^15.6.1",
         "simplebar": "^5.1.0"
-      }
-    },
-    "simplebar-react-legacy": {
-      "version": "npm:simplebar-react@1.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
-      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-      "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^4.2.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-          "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
-        },
-        "simplebar": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
-          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-          "requires": {
-            "can-use-dom": "^0.1.0",
-            "core-js": "^3.0.1",
-            "lodash.debounce": "^4.0.8",
-            "lodash.memoize": "^4.1.2",
-            "lodash.throttle": "^4.1.1",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        }
       }
     },
     "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/node": "12.20.27",
     "@types/numeral": "2.0.2",
     "@types/react": "17.0.33",
-    "@types/react-native": "0.60.31",
+    "@types/react-native": "0.66.3",
     "@types/react-native-push-notification": "7.3.2",
     "@types/react-native-video": "3.1.5",
     "@types/react-redux": "7.1.18",

--- a/src/components/audio/Airplay.tsx
+++ b/src/components/audio/Airplay.tsx
@@ -67,7 +67,7 @@ const Airplay = ({ webRef }: OwnProps) => {
     }
   }, [webRef, listenerRef])
 
-  return <AirplayViewManager style={{ display: 'none' }} />
+  return <AirplayViewManager />
 }
 
 export default Airplay

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -496,7 +496,7 @@ const Drawer = ({
   })
 
   const renderBackground = () => {
-    const renderBackgroundView = (options?: { pointerEvents: string }) => (
+    const renderBackgroundView = (options?: { pointerEvents: 'none' }) => (
       <Animated.View
         pointerEvents={options?.pointerEvents}
         style={[styles.background, { opacity: backgroundOpacityAnim }]}

--- a/src/components/search/TopBar.tsx
+++ b/src/components/search/TopBar.tsx
@@ -183,7 +183,7 @@ const TopBar = ({ onClose, isOpen }: TopBarProps) => {
           onChangeText={onChangeText}
           underlineColorAndroid='transparent'
           style={inputStyles}
-          autoComplete={'off'}
+          autoComplete='off'
           autoCorrect={false}
           returnKeyType={'search'}
           onSubmitEditing={onSubmit}

--- a/src/components/search/TopBar.tsx
+++ b/src/components/search/TopBar.tsx
@@ -183,7 +183,7 @@ const TopBar = ({ onClose, isOpen }: TopBarProps) => {
           onChangeText={onChangeText}
           underlineColorAndroid='transparent'
           style={inputStyles}
-          autoCompleteType={'off'}
+          autoComplete={'off'}
           autoCorrect={false}
           returnKeyType={'search'}
           onSubmitEditing={onSubmit}

--- a/src/components/signon/CreatePassword.tsx
+++ b/src/components/signon/CreatePassword.tsx
@@ -487,7 +487,7 @@ const CreatePassword = ({ navigation, route }: CreatePasswordProps) => {
                     placeholderTextColor='#C2C0CC'
                     underlineColorAndroid='transparent'
                     placeholder='Password'
-                    autoCompleteType='off'
+                    autoComplete='off'
                     autoCorrect={false}
                     autoCapitalize='none'
                     enablesReturnKeyAutomatically={true}
@@ -528,7 +528,7 @@ const CreatePassword = ({ navigation, route }: CreatePasswordProps) => {
                     placeholderTextColor='#C2C0CC'
                     underlineColorAndroid='transparent'
                     placeholder='Confirm Password'
-                    autoCompleteType='off'
+                    autoComplete='off'
                     autoCorrect={false}
                     autoCapitalize='none'
                     enablesReturnKeyAutomatically={true}

--- a/src/components/signon/ProfileManual.tsx
+++ b/src/components/signon/ProfileManual.tsx
@@ -524,7 +524,7 @@ const ProfileManual = ({ navigation, route }: ProfileManualProps) => {
                   underlineColorAndroid='transparent'
                   placeholder='Display Name'
                   keyboardType='default'
-                  autoCompleteType='off'
+                  autoComplete='off'
                   autoCorrect={false}
                   autoCapitalize='words'
                   enablesReturnKeyAutomatically={true}
@@ -555,7 +555,7 @@ const ProfileManual = ({ navigation, route }: ProfileManualProps) => {
                     underlineColorAndroid='transparent'
                     placeholder='Handle'
                     keyboardType='email-address'
-                    autoCompleteType='off'
+                    autoComplete='off'
                     autoCorrect={false}
                     autoCapitalize='none'
                     enablesReturnKeyAutomatically={true}

--- a/src/components/signon/SignOn.tsx
+++ b/src/components/signon/SignOn.tsx
@@ -549,7 +549,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
           placeholderTextColor='#C2C0CC'
           underlineColorAndroid='transparent'
           placeholder='Password'
-          autoCompleteType='off'
+          autoComplete='off'
           autoCorrect={false}
           autoCapitalize='none'
           enablesReturnKeyAutomatically={true}
@@ -703,7 +703,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
               underlineColorAndroid='transparent'
               placeholder='Email'
               keyboardType='email-address'
-              autoCompleteType='off'
+              autoComplete='off'
               autoCorrect={false}
               autoCapitalize='none'
               enablesReturnKeyAutomatically={true}

--- a/src/components/toast/ToastView.tsx
+++ b/src/components/toast/ToastView.tsx
@@ -68,8 +68,16 @@ const ToastView = ({ content, timeout, type = 'info' }: ToastViewProps) => {
   const opacityAnim = useRef(new Animated.Value(0)).current
 
   const animOut = useCallback(() => {
-    Animated.spring(opacityAnim, { ...springConfig, toValue: 0 }).start()
-    Animated.spring(translationAnim, { ...springConfig, toValue: 0 }).start()
+    Animated.spring(opacityAnim, {
+      ...springConfig,
+      toValue: 0,
+      useNativeDriver: true
+    }).start()
+    Animated.spring(translationAnim, {
+      ...springConfig,
+      toValue: 0,
+      useNativeDriver: true
+    }).start()
   }, [translationAnim, opacityAnim])
 
   const animIn = useCallback(() => {
@@ -78,10 +86,15 @@ const ToastView = ({ content, timeout, type = 'info' }: ToastViewProps) => {
         animOut()
       }, timeout)
     }
-    Animated.spring(opacityAnim, { ...springConfig, toValue: 1 }).start()
+    Animated.spring(opacityAnim, {
+      ...springConfig,
+      toValue: 1,
+      useNativeDriver: true
+    }).start()
     Animated.spring(translationAnim, {
       ...springConfig,
-      toValue: DISTANCE_DOWN
+      toValue: DISTANCE_DOWN,
+      useNativeDriver: true
     }).start(callback)
   }, [translationAnim, opacityAnim, animOut, timeout])
 


### PR DESCRIPTION
### Description

This PR upgrades `@types/react-native` to `0.66.3`. I should have done this as part of the react-native upgrade but missed it

This allows us to use `Pressable` and other v66 features

### Dragons

Removes the `display: none` on the AirplayViewManager because the style prop does not exist on it. I tested to make sure it does not display

### How Has This Been Tested?

Checked that there are no type errors. Tested updated components on ios simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
