### PR TITLE
Add ScreenHeader component and add skeleton for explore screen tab components

### DIFF
--- a/src/components/top-tab-bar/TopTabBar.tsx
+++ b/src/components/top-tab-bar/TopTabBar.tsx
@@ -42,8 +42,14 @@ const createTabBarStyles = (themeColors: ThemeColors) =>
   StyleSheet.create({
     tabBarContainer: {
       flexDirection: 'row',
+      marginBottom: -4,
       paddingBottom: 4,
-      position: 'relative'
+      position: 'relative',
+      zIndex: 100,
+      shadowColor: themeColors.neutralDark1,
+      shadowOpacity: 0.15,
+      shadowOffset: { height: 2, width: 0 },
+      shadowRadius: 5
     },
 
     tabContainer: {

--- a/src/screens/ScreenHeader.tsx
+++ b/src/screens/ScreenHeader.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { StyleSheet, View } from 'react-native'
+
+import GradientText from 'app/components/gradient-text'
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+type Props = {
+  text: string
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    headerContainer: {
+      backgroundColor: themeColors.white,
+      height: 52,
+      borderBottomWidth: 1,
+      borderBottomColor: themeColors.neutralLight8
+    },
+    header: {
+      fontSize: 24,
+      marginLeft: 12,
+      lineHeight: 52,
+      textShadowOffset: { height: 2 },
+      textShadowRadius: 4,
+      textShadowColor: 'rgba(162,47,235,0.2)'
+    }
+  })
+
+export const ScreenHeader = ({ text }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  return (
+    <View style={styles.headerContainer}>
+      <GradientText style={styles.header} text={text} />
+    </View>
+  )
+}

--- a/src/screens/explore-screen/ExploreScreen.tsx
+++ b/src/screens/explore-screen/ExploreScreen.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { Button, Dimensions, Text, View } from 'react-native'
+import { Dimensions, View } from 'react-native'
 
 import IconForYou from 'app/assets/images/iconExploreForYou.svg'
 import IconMoods from 'app/assets/images/iconExploreMoods.svg'
@@ -10,43 +10,27 @@ import IconUser from 'app/assets/images/iconUser.svg'
 import TopTabNavigator from 'app/components/app-navigator/TopTabNavigator'
 import { ExploreStackParamList } from 'app/components/app-navigator/types'
 
+import { ScreenHeader } from '../ScreenHeader'
+
+import { ArtistsTab } from './tabs/ArtistsTab'
+import { ForYouTab } from './tabs/ForYouTab'
+import { MoodsTab } from './tabs/MoodsTab'
+import { PlaylistsTab } from './tabs/PlaylistsTab'
+
 type Props = NativeStackScreenProps<ExploreStackParamList, 'explore-stack'>
 
 const screenHeight = Dimensions.get('window').height
-
-const ForYouTab = () => {
-  return <Text>For You Tab</Text>
-}
-const MoodsTab = () => {
-  return <Text>Moods Tab</Text>
-}
-const PlaylistsTab = () => {
-  return <Text>Playlists Tab</Text>
-}
-const ArtistsTab = ({ navigation }) => {
-  const handlePress = useCallback(() => {
-    navigation.navigate('profile', { id: 1 })
-  }, [navigation])
-
-  return (
-    <View>
-      <Text>Artists Tab</Text>
-      <Button title='Go to single artist view' onPress={handlePress} />
-    </View>
-  )
-}
 
 const ExploreScreen = ({ navigation }: Props) => {
   return (
     <View
       style={{
         display: 'flex',
-        flexDirection: 'column',
         height: screenHeight
       }}
     >
-      <Text style={{ flex: 1 }}>Example explore screen</Text>
-      <View style={{ flex: 10 }}>
+      <ScreenHeader text={'Explore'} />
+      <View style={{ flex: 1 }}>
         <TopTabNavigator
           initialScreen='tracks'
           screens={[

--- a/src/screens/explore-screen/tabs/ArtistsTab.tsx
+++ b/src/screens/explore-screen/tabs/ArtistsTab.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback } from 'react'
+
+import { ParamListBase } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { Button, StyleSheet, View } from 'react-native'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+import { TabInfo } from './TabInfo'
+
+const messages = {
+  infoHeader: 'Featured Artists'
+}
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase, keyof ParamListBase>
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    tabContainer: {
+      display: 'flex'
+    },
+    contentContainer: {
+      display: 'flex'
+    }
+  })
+
+export const ArtistsTab = ({ navigation }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  const handlePress = useCallback(() => {
+    navigation.navigate('profile', { id: 1 })
+  }, [navigation])
+
+  return (
+    <View style={styles.tabContainer}>
+      <TabInfo header={messages.infoHeader} />
+      <View style={styles.contentContainer}>
+        <Button title='Go to single artist view' onPress={handlePress} />
+      </View>
+    </View>
+  )
+}

--- a/src/screens/explore-screen/tabs/ForYouTab.tsx
+++ b/src/screens/explore-screen/tabs/ForYouTab.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import { ParamListBase } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { StyleSheet, View } from 'react-native'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+import { TabInfo } from './TabInfo'
+
+const messages = {
+  infoHeader: 'Just For You',
+  infoText:
+    'Content curated for you based on your likes, reposts, and follows. Refreshes often so if you like a track, favorite it.'
+}
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase, keyof ParamListBase>
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    tabContainer: {
+      display: 'flex'
+    },
+    contentContainer: {
+      display: 'flex'
+    }
+  })
+
+export const ForYouTab = ({ navigation }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  return (
+    <View style={styles.tabContainer}>
+      <TabInfo header={messages.infoHeader} text={messages.infoText} />
+      <View style={styles.contentContainer} />
+    </View>
+  )
+}

--- a/src/screens/explore-screen/tabs/MoodsTab.tsx
+++ b/src/screens/explore-screen/tabs/MoodsTab.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+import { ParamListBase } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { StyleSheet, View } from 'react-native'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+import { TabInfo } from './TabInfo'
+
+const messages = {
+  infoHeader: 'Playlists to Fit Your Mood',
+  infoText: 'Playlists made by Audius users, sorted by mood and feel.'
+}
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase, keyof ParamListBase>
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    tabContainer: {
+      display: 'flex'
+    },
+    contentContainer: {
+      display: 'flex'
+    }
+  })
+
+export const MoodsTab = ({ navigation }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  return (
+    <View style={styles.tabContainer}>
+      <TabInfo header={messages.infoHeader} text={messages.infoText} />
+      <View style={styles.contentContainer} />
+    </View>
+  )
+}

--- a/src/screens/explore-screen/tabs/PlaylistsTab.tsx
+++ b/src/screens/explore-screen/tabs/PlaylistsTab.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { ParamListBase } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { StyleSheet, View } from 'react-native'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+import { TabInfo } from './TabInfo'
+
+const messages = {
+  infoHeader: 'Featured Playlists'
+}
+
+type Props = {
+  navigation: NativeStackNavigationProp<ParamListBase, keyof ParamListBase>
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    tabContainer: {
+      display: 'flex'
+    },
+    contentContainer: {
+      display: 'flex'
+    }
+  })
+
+export const PlaylistsTab = ({ navigation }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  return (
+    <View style={styles.tabContainer}>
+      <TabInfo header={messages.infoHeader} />
+      <View style={styles.contentContainer} />
+    </View>
+  )
+}

--- a/src/screens/explore-screen/tabs/TabInfo.tsx
+++ b/src/screens/explore-screen/tabs/TabInfo.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { StyleSheet, Text, View } from 'react-native'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors } from 'app/utils/theme'
+
+type Props = {
+  header: string
+  text?: string
+}
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    infoContainer: {
+      backgroundColor: themeColors.white,
+      display: 'flex',
+      padding: 16,
+      paddingLeft: 28,
+      paddingRight: 28,
+      shadowOffset: { height: 10, width: 0 },
+      shadowRadius: 15,
+      shadowColor: 'rgb(133,129,153)',
+      shadowOpacity: 0.15
+    },
+    header: {
+      color: themeColors.secondary,
+      fontFamily: 'AvenirNextLTPro-Bold',
+      fontSize: 20,
+      letterSpacing: 0.25,
+      lineHeight: 25
+    },
+    text: {
+      color: themeColors.neutral,
+      fontFamily: 'AvenirNextLTPro-Regular',
+      fontSize: 16,
+      fontWeight: '500',
+      letterSpacing: 0,
+      lineHeight: 23,
+      marginTop: 6
+    }
+  })
+
+export const TabInfo = ({ header, text }: Props) => {
+  const styles = useThemedStyles(createStyles)
+
+  return (
+    <View style={styles.infoContainer}>
+      <Text style={styles.header}>{header}</Text>
+      {text && <Text style={styles.text}>{text}</Text>}
+    </View>
+  )
+}


### PR DESCRIPTION
### Description
Adding the skeleton for the explore screen tabs and the reusable components for screens and tabs

May need to move the TabInfo component to a different location if other screens need it
