### PR TITLE
Add `renderIcon` prop to button, fix margins

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,7 +8,8 @@ import {
   TextStyle,
   View,
   Animated,
-  StyleProp
+  StyleProp,
+  ColorValue
 } from 'react-native'
 
 import Text from 'app/components/text'
@@ -111,7 +112,7 @@ export type ButtonProps = {
    * const renderIconArrow = color => <IconArrow fill={color} />
    * export const myComponent = () => <Button renderIcon={renderIconArrow} />
    */
-  renderIcon?: (color: string) => React.ReactElement
+  renderIcon?: (color: ColorValue) => React.ReactElement
   iconPosition?: 'left' | 'right'
   containerStyle?: StyleProp<ViewStyle>
   style?: StyleProp<ViewStyle>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -25,7 +25,9 @@ interface ButtonStyle {
   button: ViewStyle
   buttonContent: ViewStyle
   buttonText: TextStyle
-  icon: ViewStyle
+  icon: TextStyle
+  iconRight: ViewStyle
+  iconLeft: ViewStyle
   disabled: ViewStyle
 }
 
@@ -35,6 +37,9 @@ const buttonTypeStyles = {
       backgroundColor: themeColors.primary
     },
     buttonText: {
+      color: themeColors.staticWhite
+    },
+    icon: {
       color: themeColors.staticWhite
     }
   }),
@@ -74,6 +79,12 @@ const createStyles = (type: ButtonType = ButtonType.PRIMARY) => (
           fontFamily: 'AvenirNextLTPro-Bold'
         },
         icon: {
+          color: themeColors.neutralLight4
+        },
+        iconLeft: {
+          marginRight: 12
+        },
+        iconRight: {
           marginLeft: 12
         },
         disabled: {
@@ -88,7 +99,19 @@ export type ButtonProps = {
   title: string
   onPress: () => void
   type?: ButtonType
+  /**
+   * The element to render for the icon
+   * @deprecated use the `renderIcon` prop instead in order to ensure the proper color is used to style the icon.
+   */
   icon?: React.ReactElement
+  /**
+   * Callback accepting the themed color of the button text that returns the resulting icon element.
+   * Takes priority over the `icon` prop. Define the callback outside of a render function to prevent rerenders.
+   * @example
+   * const renderIconArrow = color => <IconArrow fill={color} />
+   * export const myComponent = () => <Button renderIcon={renderIconArrow} />
+   */
+  renderIcon?: (color: string) => React.ReactElement
   iconPosition?: 'left' | 'right'
   containerStyle?: StyleProp<ViewStyle>
   style?: StyleProp<ViewStyle>
@@ -103,6 +126,7 @@ const Button = ({
   onPress,
   type = ButtonType.PRIMARY,
   icon,
+  renderIcon,
   iconPosition = 'right',
   containerStyle,
   style,
@@ -111,7 +135,7 @@ const Button = ({
   ignoreDisabledStyle = false,
   underlayColor
 }: ButtonProps) => {
-  const styles = useThemedStyles(createStyles(type))
+  const styles: ButtonStyle = useThemedStyles(createStyles(type))
   const { primaryDark1 } = useThemeColors()
   const scale = useRef(new Animated.Value(1)).current
 
@@ -154,12 +178,16 @@ const Button = ({
         style={[styles.button, style]}
       >
         <View style={styles.buttonContent}>
-          {icon && iconPosition === 'left' ? (
-            <View style={styles.icon}>{icon}</View>
+          {(icon || renderIcon) && iconPosition === 'left' ? (
+            <View style={styles.iconLeft}>
+              {renderIcon ? renderIcon(styles.icon.color) : icon}
+            </View>
           ) : null}
           <Text style={[styles.buttonText, textStyle]}>{title}</Text>
-          {icon && iconPosition === 'right' ? (
-            <View style={styles.icon}>{icon}</View>
+          {(icon || renderIcon) && iconPosition === 'right' ? (
+            <View style={styles.iconRight}>
+              {renderIcon ? renderIcon(styles.icon.color) : icon}
+            </View>
           ) : null}
         </View>
       </TouchableHighlight>


### PR DESCRIPTION
### Description

- Adds a `renderIcon` prop to the button, which accepts a callback that takes a color and returns an element
- Deprecates `icon` to encourage using the proper color for icons
- Adjusts `icon` styles to have proper margins depending on whether the icon is on the right or left

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested manually against upcoming `ChallengeRewardsDrawer` changes, which uses both button styles and also both deprecated and new props.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A