### PR TITLE
Improve webApp render flow and missing store edge-cases

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import createStore from 'app/store'
 import { setup as setupAnalytics } from 'app/utils/analytics'
 
 import ErrorBoundary from './ErrorBoundary'
+import { WebAppManager } from './WebAppManager'
 import { ThemeContextProvider } from './components/theme/ThemeContext'
 
 Sentry.init({
@@ -111,21 +112,17 @@ const App = () => {
             <NavigationContainer>
               <Provider store={store}>
                 <WebRefContextProvider>
-                  <GoogleCast webRef={webRef} />
-                  <WebApp webRef={webRef} />
-                  {/*
-                Note: it is very important that components are rendered after WebApp.
-                On Android, regardless of position: absolute, WebApp will steal all of
-                touch targets and onPress will not work.
-              */}
-                  <AppNavigator />
-                  <Search />
-                  <Notifications webRef={webRef} />
-                  <Drawers />
-                  <Modals />
-                  <Audio webRef={webRef} />
-                  <OAuth webRef={webRef} />
-                  <Airplay webRef={webRef} />
+                  <WebAppManager webApp={<WebApp webRef={webRef} />}>
+                    <GoogleCast webRef={webRef} />
+                    <AppNavigator />
+                    <Search />
+                    <Notifications webRef={webRef} />
+                    <Drawers />
+                    <Modals />
+                    <Audio webRef={webRef} />
+                    <OAuth webRef={webRef} />
+                    <Airplay webRef={webRef} />
+                  </WebAppManager>
                 </WebRefContextProvider>
               </Provider>
             </NavigationContainer>

--- a/src/WebAppManager.tsx
+++ b/src/WebAppManager.tsx
@@ -1,12 +1,9 @@
 import React, { ReactNode } from 'react'
 
-import { CommonState } from 'audius-client/src/common/store'
 import { isEmpty } from 'lodash'
 import { useSelector } from 'react-redux'
 
-type NativeRootState = {
-  clientStore?: CommonState
-}
+import { AppState } from './store'
 
 type WebAppManagerProps = {
   webApp: JSX.Element
@@ -14,7 +11,7 @@ type WebAppManagerProps = {
 }
 
 export const WebAppManager = ({ webApp, children }: WebAppManagerProps) => {
-  const clientStore = useSelector((state: NativeRootState) => state.clientStore)
+  const clientStore = useSelector((state: AppState) => state.clientStore)
   const isClientStoreEmpty = isEmpty(clientStore)
   return (
     <>

--- a/src/WebAppManager.tsx
+++ b/src/WebAppManager.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from 'react'
+
+import { CommonState } from 'audius-client/src/common/store'
+import { isEmpty } from 'lodash'
+import { useSelector } from 'react-redux'
+
+type NativeRootState = {
+  clientStore?: CommonState
+}
+
+type WebAppManagerProps = {
+  webApp: JSX.Element
+  children: ReactNode
+}
+
+export const WebAppManager = ({ webApp, children }: WebAppManagerProps) => {
+  const clientStore = useSelector((state: NativeRootState) => state.clientStore)
+  const isClientStoreEmpty = isEmpty(clientStore)
+  return (
+    <>
+      {webApp}
+      {/*
+        Note: it is very important that native components are rendered after WebApp.
+        On Android, regardless of position: absolute, WebApp will steal all of
+        touch targets and onPress will not work. We also check if the client store
+        is initialized before continuing.
+      */}
+      {isClientStoreEmpty ? null : children}
+    </>
+  )
+}

--- a/src/hooks/useSelectorWeb.ts
+++ b/src/hooks/useSelectorWeb.ts
@@ -1,5 +1,4 @@
 import { CommonState } from 'audius-client/src/common/store'
-import { isEmpty } from 'lodash'
 import { Selector, useSelector } from 'react-redux'
 
 // When mobile client is no longer dependent on the web client
@@ -8,6 +7,6 @@ export const useSelectorWeb = <ReturnValue>(
   selector: Selector<CommonState, ReturnValue>
 ) => {
   return useSelector((state: { clientStore: CommonState }) =>
-    isEmpty(state.clientStore) ? undefined : selector(state.clientStore)
+    selector(state.clientStore)
   )
 }


### PR DESCRIPTION
### Description

- Adds WebAppManager to establish requirement that the web-app needs to render above native app
- Adds a check in render flow to ensure clientStore is available before rendering the rest of the native app. This simplifies `useSelectorWeb` implementation, and prevents bugs where data returned by useSelectorWeb is undefined for the first render. Weirdly enough typescript wasn't picking up the fact that `useSelectorWeb` can return undefined, so something like `const {a, b} = useSelectorWeb(someSelector)` results in a runtime error, `can't resolve a of undefined`

### Dragons

This change affects the root of the app, so there is a potential for things to break in weird ways.