### PR TITLE
Upload Bounce on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,8 +256,7 @@ jobs:
           env: '.env.stage'
       - when:
           condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+            matches: { pattern: '^master$', value: << pipeline.git.branch >> }
           steps:
             - upload-ios:
                 bundle-id: 'co.audius.audiusmusic.bounce'
@@ -296,8 +295,7 @@ jobs:
           remote-directory: 'audius-mobile-staging'
       - when:
           condition:
-            matches:
-              { pattern: '^release.*$', value: << pipeline.git.branch >> }
+            matches: { pattern: '^master$', value: << pipeline.git.branch >> }
           steps:
             - upload-android:
                 upload-type: 'bounce'


### PR DESCRIPTION
### Description

This PR:
* Updates CI to upload the Bounce app to testflight on pushes to `master` instead of release branches

This means that Bounce will always have latest master and we don't need to create a release branch to test features. We could potentially include release branches in the regex too, the only use case I can see for that is a hotfix on a release branch that we want to test on Bounce. Not sure if this would ever happen

### Dragons

### How Has This Been Tested?


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
