### PR TITLE
[AUD-1278] Use common analytics types

### DIFF
--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,5 +1,3 @@
-import { Message as _Message } from './types'
-
 export { MessageType } from './types'
-export type Message = _Message
+export type { Message } from './types'
 export { handleMessage } from './handleMessage'

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,6 +1,29 @@
-import { Message } from '../message/types'
+import {
+  Name as CommonEventNames,
+  AllTrackingEvents as CommonTrackingEvents
+} from 'audius-client/src/common/models/Analytics'
 
-type JsonMap = Record<string, unknown>
+import { Message } from 'app/message'
+
+export * from 'audius-client/src/common/models/Analytics'
+
+enum MobileEventNames {
+  NOTIFICATIONS_OPEN_PUSH_NOTIFICATION = 'Notifications: Open Push Notification'
+}
+
+export const EventNames = { ...CommonEventNames, ...MobileEventNames }
+
+type NotificationsOpenPushNotification = {
+  eventName: MobileEventNames.NOTIFICATIONS_OPEN_PUSH_NOTIFICATION
+  title?: string
+  body?: string
+}
+
+type MobileTrackingEvents = NotificationsOpenPushNotification
+
+export type AllEvents = CommonTrackingEvents | MobileTrackingEvents
+
+export type JsonMap = Record<string, unknown>
 
 export type Identify = {
   handle: string
@@ -18,144 +41,3 @@ export type Screen = {
 }
 
 export type AnalyticsMessage = Message & (Identify | Track | Screen)
-
-export enum EventNames {
-  // Account creation
-  // When the user opens the create account page
-  CREATE_ACCOUNT_OPEN = 'Create Account: Open',
-  // When the user continues past the password page
-  CREATE_ACCOUNT_COMPLETE_PASSWORD = 'Create Account: Complete Password',
-  // When the user starts integrating with twitter
-  CREATE_ACCOUNT_START_TWITTER = 'Create Account: Start Twitter',
-  // When the user continues past the "twitter connection page"
-  CREATE_ACCOUNT_COMPLETE_TWITTER = 'Create Account: Complete Twitter',
-  // When the user starts integrating with instagram
-  CREATE_ACCOUNT_START_INSTAGRAM = 'Create Account: Start Instagram',
-  // When the user continues past the "instagram connection page"
-  CREATE_ACCOUNT_COMPLETE_INSTAGRAM = 'Create Account: Complete Instagram',
-  // When the user continues past the "profile info page"
-  CREATE_ACCOUNT_COMPLETE_PROFILE = 'Create Account: Complete Profile',
-  // When the user continues past the follow page
-  CREATE_ACCOUNT_COMPLETE_FOLLOW = 'Create Account: Complete Follow',
-  // When the user continues past the loading page (in mobile this signifies sign up is complete)
-  CREATE_ACCOUNT_FINISH = 'Create Account: Finish',
-
-  // Sign in
-  SIGN_IN_OPEN = 'Sign In: Open',
-
-  // Playback
-  PLAYBACK_PLAY = 'Playback: Play',
-  PLAYBACK_PAUSE = 'Playback: Pause',
-  // A listen is when we record against the backend vs. a play which is a UI action
-  LISTEN = 'Listen',
-
-  // Notifications
-  NOTIFICATIONS_OPEN_PUSH_NOTIFICATION = 'Notifications: Open Push Notification',
-
-  // Page View
-  PAGE_VIEW = 'Page View',
-
-  // TikTok
-  TIKTOK_OAUTH_ERROR = 'TikTok: TikTok OAuth Error'
-}
-
-// Create Account
-type CreateAccountOpen = {
-  eventName: EventNames.CREATE_ACCOUNT_OPEN
-  source: 'sign in page'
-}
-type CreateAccountCompletePassword = {
-  eventName: EventNames.CREATE_ACCOUNT_COMPLETE_PASSWORD
-  emailAddress: string
-}
-type CreateAccountStartTwitter = {
-  eventName: EventNames.CREATE_ACCOUNT_START_TWITTER
-  emailAddress: string
-}
-type CreateAccountCompleteTwitter = {
-  eventName: EventNames.CREATE_ACCOUNT_COMPLETE_TWITTER
-  isVerified: boolean
-  emailAddress: string
-  handle: string
-}
-type CreateAccountStartInstagram = {
-  eventName: EventNames.CREATE_ACCOUNT_START_INSTAGRAM
-  emailAddress: string
-}
-type CreateAccountCompleteInstagram = {
-  eventName: EventNames.CREATE_ACCOUNT_COMPLETE_INSTAGRAM
-  isVerified: boolean
-  emailAddress: string
-  handle: string
-}
-type CreateAccountCompleteProfile = {
-  eventName: EventNames.CREATE_ACCOUNT_COMPLETE_PROFILE
-  emailAddress: string
-  handle: string
-}
-type CreateAccountCompleteFollow = {
-  eventName: EventNames.CREATE_ACCOUNT_COMPLETE_FOLLOW
-  emailAddress: string
-  handle: string
-  users: string
-  count: number
-}
-type CreateAccountOpenFinish = {
-  eventName: EventNames.CREATE_ACCOUNT_FINISH
-  emailAddress: string
-  handle: string
-}
-
-type SignInOpen = {
-  eventName: EventNames.SIGN_IN_OPEN
-  source: 'sign up page'
-}
-
-export type Listen = {
-  eventName: EventNames.LISTEN
-  trackId: string
-}
-
-export enum PlaybackSource {
-  PASSIVE = 'passive'
-}
-
-type PlaybackPlay = {
-  eventName: EventNames.PLAYBACK_PLAY
-  id?: string
-  source: PlaybackSource
-}
-type PlaybackPause = {
-  eventName: EventNames.PLAYBACK_PAUSE
-  id?: string
-  source: PlaybackSource
-}
-
-type NotificationsOpenPushNotification = {
-  eventName: EventNames.NOTIFICATIONS_OPEN_PUSH_NOTIFICATION
-  title?: string
-  body?: string
-}
-
-// TikTok
-type TikTokOAuthError = {
-  eventName: EventNames.TIKTOK_OAUTH_ERROR
-  error: string
-}
-
-export type AllEvents =
-  | CreateAccountOpen
-  | CreateAccountCompletePassword
-  | CreateAccountStartTwitter
-  | CreateAccountCompleteTwitter
-  | CreateAccountStartInstagram
-  | CreateAccountCompleteInstagram
-  | CreateAccountCompleteProfile
-  | CreateAccountCompleteFollow
-  | CreateAccountOpenFinish
-  | SignInOpen
-  | Listen
-  | PlaybackPlay
-  | PlaybackPause
-  | NotificationsOpenPushNotification
-  | TikTokOAuthError

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -5,8 +5,6 @@ import {
 
 import { Message } from 'app/message'
 
-export * from 'audius-client/src/common/models/Analytics'
-
 enum MobileEventNames {
   NOTIFICATIONS_OPEN_PUSH_NOTIFICATION = 'Notifications: Open Push Notification'
 }
@@ -41,3 +39,12 @@ export type Screen = {
 }
 
 export type AnalyticsMessage = Message & (Identify | Track | Screen)
+
+export {
+  PlaybackSource,
+  ShareSource,
+  RepostSource,
+  FavoriteSource,
+  FollowSource,
+  CreatePlaylistSource
+} from 'audius-client/src/common/models/Analytics'


### PR DESCRIPTION
### Description

Removes duplicate analytics types and uses the common ones from `audius-client`

### Dragons

There is a bit of funkiness required to merge the common enums with the native specific ones. One one hand it makes sense to have native specific extensions, but i can also see the argument to put them all in common. I'm up for either so lmk. Mobile also uses different naming conventions for analytics, like `Name.AnalyticsEvent` vs `EventNames.AnalyticsEvent`, and `AllEvents` vs `AllAnalyticsEvents`. happy to approach unifying those names now if it makes sense
