### PR TITLE
Fix style type for ColorTile

### DIFF
--- a/src/screens/explore-screen/components/ColorTile.tsx
+++ b/src/screens/explore-screen/components/ColorTile.tsx
@@ -143,11 +143,11 @@ export const ColorTile = ({
         style={styles.gradientContainer}
       >
         <TouchableOpacity
-          style={[styles.colorTile, emoji && styles.hasEmoji]}
+          style={[styles.colorTile, !!emoji && styles.hasEmoji]}
           onPress={() => goToRoute(link)}
         >
           <View style={{ backgroundColor: 'transparent' }}>
-            <Text style={[styles.title, emoji && styles.emojiTitle]}>
+            <Text style={[styles.title, !!emoji && styles.emojiTitle]}>
               {title}
             </Text>
             <Text style={styles.description}>{description}</Text>


### PR DESCRIPTION
### Description

Interesting case where `emoji` as a React.Node means it can have falsy values like 0, which messes with styles acceptable falsy values

### Dragons

used `!!` here but could also do `Boolean(..)`, do we have a pref?