### PR TITLE
[AUD-1293] Fix crash when opening link without app open

### DIFF
--- a/src/hooks/useIsStackOpen.ts
+++ b/src/hooks/useIsStackOpen.ts
@@ -10,7 +10,8 @@ import { getNavigationStateAtRoute } from 'app/utils/navigation'
 const useIsStackOpen = () => {
   const state = useNavigationState(getNavigationStateAtRoute(['main']))
 
-  if (!state) {
+  // state.index is potentially undefined, but this isn't specified in it's type
+  if (!state || state.index === undefined) {
     return false
   }
 


### PR DESCRIPTION
### Description

This PR fixes an issue where the app crashes (white/black screen) when opening a link without the app open. This happens because of a missing null check in  a piece of the new navigation logic. Although most of the navigation logic is disabled in prod, we are using a hook in notifications to determine if a stack is open. We could probably disable this via the `IS_MAIN_NAVIGATION_ENABLED` env var, but it needs to be fixed anyway and I think this is the quickest solution.

Unfortunately the type for `state.index` is number, so there was no indication that it could potentially be undefined at runtime. Might be worth adding a type declaration to override it, so we don't run into this again

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested on ios device

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
