### PR TITLE
[AUD-1302] Confirm that link can be opened from TweetEmbed

### DIFF
--- a/src/components/tweet-embed/TweetEmbed.tsx
+++ b/src/components/tweet-embed/TweetEmbed.tsx
@@ -74,7 +74,11 @@ const TweetEmbed = ({ options, tweetId }: Props) => {
           onShouldStartLoadWithRequest={request => {
             // Open subsequent links in browser
             if (!isLoading) {
-              Linking.openURL(request.url)
+              Linking.canOpenURL(request.url).then(supported => {
+                if (supported) {
+                  Linking.openURL(request.url)
+                }
+              })
             }
             return isLoading
           }}


### PR DESCRIPTION
### Description

This PR wraps the request to open a url from the TweetEmbed component in a check for `canOpenURL`. This should prevent the most common log we are seeing in Sentry

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
