### PR TITLE
[AUD-1303] Fix warnings & deprecations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10508,6 +10508,11 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
+        "core-js": {
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag=="
+        },
         "fxa-common-password-list": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.2.tgz",
@@ -10560,6 +10565,28 @@
           "version": "2.13.8",
           "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
           "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+        },
+        "simplebar": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+          "requires": {
+            "can-use-dom": "^0.1.0",
+            "core-js": "^3.0.1",
+            "lodash.debounce": "^4.0.8",
+            "lodash.memoize": "^4.1.2",
+            "lodash.throttle": "^4.1.1",
+            "resize-observer-polyfill": "^1.5.1"
+          }
+        },
+        "simplebar-react-legacy": {
+          "version": "npm:simplebar-react@1.2.3",
+          "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+          "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+          "requires": {
+            "prop-types": "^15.6.1",
+            "simplebar": "^4.2.3"
+          }
         }
       }
     },
@@ -28691,9 +28718,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.22.1.tgz",
-      "integrity": "sha512-pvpNDHE7p0FtcCmIWGazoY8LLVfBI9sw0Kf10kdHhPI9Tzt3OG/qEt16GrAbE0keuna5WzX3r1qPKVjqOqsuUg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.14.0.tgz",
+      "integrity": "sha512-cE7tkSUkGCDxTA79pntDGJCBgzNN/XxA3kgPdXujdfSfEfVhzrItQIEsN0kCN/hJJACDvH2Q8p5+tJb/K4B3qA==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -33239,35 +33266,6 @@
       "requires": {
         "prop-types": "^15.6.1",
         "simplebar": "^5.1.0"
-      }
-    },
-    "simplebar-react-legacy": {
-      "version": "npm:simplebar-react@1.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
-      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-      "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^4.2.3"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-          "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
-        },
-        "simplebar": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
-          "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-          "requires": {
-            "can-use-dom": "^0.1.0",
-            "core-js": "^3.0.1",
-            "lodash.debounce": "^4.0.8",
-            "lodash.memoize": "^4.1.2",
-            "lodash.throttle": "^4.1.1",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        }
       }
     },
     "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "metro-react-native-babel-preset": "0.56.4",
     "prettier": "2.0.5",
     "prettier-config-standard": "1.0.1",
+    "react-devtools-core": "4.14.0",
     "react-test-renderer": "16.9.0",
     "redux-devtools-extension": "2.13.9",
     "standard": "16.0.3",

--- a/src/components/theme/ThemeContext.tsx
+++ b/src/components/theme/ThemeContext.tsx
@@ -1,24 +1,30 @@
 import React, { createContext, memo, ReactNode, useState } from 'react'
 
+import { useDarkMode } from 'react-native-dark-mode'
+
 import { Theme } from 'app/utils/theme'
 
 type ThemeContextProps = {
   setTheme: (theme: Theme) => void
   getTheme: () => Theme
+  isSystemDarkMode: boolean
 }
 
 export const ThemeContext = createContext<ThemeContextProps>({
   setTheme: () => {},
-  getTheme: () => Theme.DEFAULT
+  getTheme: () => Theme.DEFAULT,
+  isSystemDarkMode: false
 })
 
 export const ThemeContextProvider = memo((props: { children: ReactNode }) => {
   const [theme, setTheme] = useState<Theme>(Theme.DEFAULT)
+  const isSystemDarkMode = useDarkMode()
   return (
     <ThemeContext.Provider
       value={{
         setTheme,
-        getTheme: () => theme
+        getTheme: () => theme,
+        isSystemDarkMode
       }}
     >
       {props.children}

--- a/src/hooks/useAppState.ts
+++ b/src/hooks/useAppState.ts
@@ -48,8 +48,11 @@ export const useAppState = (
   )
 
   useEffect(() => {
-    AppState.addEventListener('change', handleAppStateChange)
-    return () => AppState.removeEventListener('change', handleAppStateChange)
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange
+    )
+    return () => subscription.remove()
   }, [handleAppStateChange])
 
   return appState

--- a/src/store/sagas.ts
+++ b/src/store/sagas.ts
@@ -1,5 +1,5 @@
 import remoteConfig from 'audius-client/src/common/store/remote-config/sagas'
-import { fork } from 'redux-saga/effects'
+import { all, fork } from 'redux-saga/effects'
 
 import { remoteConfigInstance } from 'app/services/remote-config/remote-config-instance'
 
@@ -12,5 +12,5 @@ export default function* rootSaga() {
     ...remoteConfig(remoteConfigInstance),
     ...oauthSagas()
   ]
-  yield sagas.map(fork)
+  yield all(sagas.map(fork))
 }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -14,13 +14,14 @@ export const handleWebAppLog = (level: LOG_LEVEL, message: string) => {
       console.log(formatted)
       break
     case 'WARNING':
+    case 'ERROR':
+      // console.error triggers an exception and an unpreventable
+      // fullscreen LogBox. Logging web app
+      // errors as a warning to prevent this
       console.warn(formatted)
       break
     case 'DEBUG':
       console.debug(formatted)
-      break
-    case 'ERROR':
-      console.error(formatted)
       break
   }
 }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,7 +1,6 @@
 import { useContext } from 'react'
 
 import { StatusBar } from 'react-native'
-import { useDarkMode } from 'react-native-dark-mode'
 
 import { ThemeContext } from 'app/components/theme/ThemeContext'
 
@@ -178,9 +177,8 @@ const themeColorsByThemeVariant = {
 }
 
 export const useThemeVariant = (): keyof typeof themeColorsByThemeVariant => {
-  const { getTheme } = useContext(ThemeContext)
+  const { isSystemDarkMode, getTheme } = useContext(ThemeContext)
   const theme = getTheme()
-  const isSystemDarkMode = useDarkMode()
 
   const systemTheme = isSystemDarkMode ? Theme.DARK : Theme.DEFAULT
   return theme === Theme.AUTO ? systemTheme : theme


### PR DESCRIPTION
### Description

This PR:
* Fixes usage of deprecated `removeEventListener`
* Fixes deprecated forking of sagas
* Fixes warning caused by calling `useDarkMode()` too often
* Changes web app errors to log as warnings, to avoid triggering fullscreen LogBox
* Fixes react devtools in react-native-debugger by installing correct version of `react-devtools-core`

### Dragons

Web App errors are now being logged as warnings instead of errors! This should only have an effect when developing, as web app errors didn't crash the app to begin with

### How Has This Been Tested?

iOS simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
