### PR TITLE
[AUD-1306] Add logging around null message sender

### DIFF
--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -18,6 +18,12 @@ export const postMessage = (sender: Maybe<MessageSender>, message: Message) => {
   }
 
   // On some versions of android the MessageSender isn't available for a short period on
-  // startup. Null check to prevent error
-  sender?.postMessage(stringified)
+  // startup. Logging more info to determine culprit message
+  if (!sender) {
+    throw new Error(
+      `MessageSender undefined. Trying to post message: ${stringified}`
+    )
+  }
+
+  sender.postMessage(stringified)
 }

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -1,3 +1,5 @@
+import { Maybe } from 'audius-client/src/common/utils/typeUtils'
+
 import { MessageType, Message } from '../message'
 
 export type MessageSender = {
@@ -7,7 +9,7 @@ export type MessageSender = {
 const SPAMMY_MESSAGES = new Set<string>([MessageType.GET_POSITION])
 
 // Stringifies the message, logs it, and sends it
-export const postMessage = (sender: MessageSender, message: Message) => {
+export const postMessage = (sender: Maybe<MessageSender>, message: Message) => {
   const stringified = JSON.stringify(message)
 
   // Log it if it isn't spammy
@@ -15,5 +17,7 @@ export const postMessage = (sender: MessageSender, message: Message) => {
     console.debug(`Sending message to web client: ${stringified}`)
   }
 
-  sender.postMessage(stringified)
+  // On some versions of android the MessageSender isn't available for a short period on
+  // startup. Null check to prevent error
+  sender?.postMessage(stringified)
 }


### PR DESCRIPTION
### Description

This PR adds extra info to logging to debug this sentry log: https://sentry.io/organizations/audius/issues/2881423499/?project=1457231&query=sdk.name%3Asentry.javascript.react-native&sort=freq&statsPeriod=14d

This SO post has more details: https://stackoverflow.com/questions/47517965/howto-solve-postmessage-from-webview-to-react-native-does-not-work-for-android

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
