### PR TITLE
[AUD-1122] Add play bar to now playing drawer

### DIFF
--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -29,7 +29,7 @@ import IconRemove from 'app/assets/images/iconRemove.svg'
 import { ThemeColors, useThemedStyles } from 'app/hooks/useThemedStyles'
 import { useColor } from 'app/utils/theme'
 
-const MAX_SHADOW_OPACITY = 0.4
+const MAX_SHADOW_OPACITY = 0.15
 const ON_MOVE_RESPONDER_DY = 10
 const MOVE_CUTOFF_CLOSE = 0.8
 const BORDER_RADIUS = 40
@@ -38,7 +38,9 @@ const BACKGROUND_OPACITY = 0.5
 // Controls the amount of friction in swiping when overflowing up or down
 const OVERFLOW_FRICTION = 4
 
-const createStyles = (zIndex = 5) => (themeColors: ThemeColors) =>
+const createStyles = (zIndex = 5, shouldAnimateShadow = true) => (
+  themeColors: ThemeColors
+) =>
   StyleSheet.create({
     drawer: {
       backgroundColor: themeColors.neutralLight10,
@@ -48,8 +50,8 @@ const createStyles = (zIndex = 5) => (themeColors: ThemeColors) =>
       width: '100%',
       elevation: zIndex,
       zIndex: zIndex,
-      shadowOpacity: 0,
-      shadowRadius: 40,
+      shadowOpacity: shouldAnimateShadow ? 0 : MAX_SHADOW_OPACITY,
+      shadowRadius: 15,
       borderTopRightRadius: BORDER_RADIUS,
       borderTopLeftRadius: BORDER_RADIUS,
       overflow: 'hidden'
@@ -168,6 +170,11 @@ export type DrawerProps = {
    */
   shouldBackgroundDim?: boolean
   /**
+   * Whether or not to animate the shadow on top of the drawer.
+   * Default to true.
+   */
+  shouldAnimateShadow?: boolean
+  /**
    * The style that controls slideIn and slideOut animations
    */
   animationStyle?: DrawerAnimationStyle
@@ -224,8 +231,8 @@ export const springToValue = (
       friction = 25
       break
     case DrawerAnimationStyle.SPRINGY:
-      tension = 160
-      friction = 15
+      tension = 70
+      friction = 10
       break
   }
   Animated.spring(animation, {
@@ -312,10 +319,11 @@ const Drawer: DrawerComponent = ({
   shouldHaveRoundedBordersAtInitialOffset = false,
   zIndex,
   drawerStyle,
+  shouldAnimateShadow,
   onPercentOpen,
   onPanResponderMove
 }: DrawerProps) => {
-  const styles = useThemedStyles(createStyles(zIndex))
+  const styles = useThemedStyles(createStyles(zIndex, shouldAnimateShadow))
 
   const { height } = Dimensions.get('window')
   const [drawerHeight, setDrawerHeight] = useState(height)
@@ -564,7 +572,9 @@ const Drawer: DrawerComponent = ({
           drawerStyle,
           ...(isFullscreen ? [styles.fullDrawer] : []),
           {
-            shadowOpacity: shadowAnim,
+            shadowOpacity: shouldAnimateShadow
+              ? shadowAnim
+              : MAX_SHADOW_OPACITY,
             transform: [
               {
                 translateY: translationAnim

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -210,7 +210,7 @@ export type DrawerProps = {
   drawerStyle?: ViewStyle
 }
 
-const springToValue = (
+export const springToValue = (
   animation: Animated.Value,
   value: number,
   animationStyle: DrawerAnimationStyle,

--- a/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/src/components/now-playing-drawer/ActionsBar.tsx
@@ -41,7 +41,7 @@ const createStyles = (themeColors: ThemeColors) =>
     }
   })
 
-const ActionsBar = () => {
+export const ActionsBar = () => {
   const styles = useThemedStyles(createStyles)
   const themeVariant = useThemeVariant()
   const isDarkMode = themeVariant === Theme.DARK
@@ -118,5 +118,3 @@ const ActionsBar = () => {
     </View>
   )
 }
-
-export default ActionsBar

--- a/src/components/now-playing-drawer/AudioControls.tsx
+++ b/src/components/now-playing-drawer/AudioControls.tsx
@@ -49,7 +49,7 @@ const createStyles = (themeColors: ThemeColors) =>
     }
   })
 
-const AudioControls = () => {
+export const AudioControls = () => {
   const styles = useThemedStyles(createStyles)
   const themeVariant = useThemeVariant()
   const isDarkMode = themeVariant === Theme.DARK
@@ -126,5 +126,3 @@ const AudioControls = () => {
     </View>
   )
 }
-
-export default AudioControls

--- a/src/components/now-playing-drawer/Logo.tsx
+++ b/src/components/now-playing-drawer/Logo.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Logo = () => {
+  return <></>
+}
+
+export default Logo

--- a/src/components/now-playing-drawer/Logo.tsx
+++ b/src/components/now-playing-drawer/Logo.tsx
@@ -1,7 +1,41 @@
 import React from 'react'
 
-const Logo = () => {
-  return <></>
+import { StyleSheet, Animated } from 'react-native'
+
+import AudiusLogoHorizontal from 'app/assets/images/audiusLogoHorizontal.svg'
+import { useThemeColors } from 'app/utils/theme'
+
+const styles = StyleSheet.create({
+  root: {
+    height: 24
+  }
+})
+
+type LogoProps = {
+  /**
+   * Opacity animation to fade in logo as
+   * the now playing drawer is dragged open.
+   */
+  opacityAnim: Animated.Value
 }
 
-export default Logo
+export const Logo = ({ opacityAnim }: LogoProps) => {
+  const { neutralLight4 } = useThemeColors()
+  return (
+    <Animated.View
+      style={[
+        styles.root,
+        {
+          opacity: opacityAnim.interpolate({
+            // Interpolate the animation such that the logo fades in
+            // at 25% up the screen.
+            inputRange: [0, 0.75, 1],
+            outputRange: [1, 0, 0]
+          })
+        }
+      ]}
+    >
+      <AudiusLogoHorizontal fill={neutralLight4} height='100%' width='100%' />
+    </Animated.View>
+  )
+}

--- a/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -6,7 +6,8 @@ import {
   Animated,
   GestureResponderEvent,
   PanResponderGestureState,
-  StatusBar
+  StatusBar,
+  Dimensions
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -15,18 +16,21 @@ import { useDrawer } from 'app/hooks/useDrawer'
 
 import { DrawerAnimationStyle, springToValue } from '../drawer/Drawer'
 
-import ActionsBar from './ActionsBar'
-import AudioControls from './AudioControls'
-import PlayBar from './PlayBar'
+import { ActionsBar } from './ActionsBar'
+import { AudioControls } from './AudioControls'
+import { Logo } from './Logo'
+import { PlayBar } from './PlayBar'
 
-const PLAY_BAR_HEIGHT = 100
+const PLAY_BAR_HEIGHT = 82
 const STATUS_BAR_FADE_CUTOFF = 0.6
 
 const styles = StyleSheet.create({
   container: {
-    padding: 24,
     paddingTop: 0,
-    height: '100%'
+    height: Dimensions.get('window').height - PLAY_BAR_HEIGHT
+  },
+  controls: {
+    padding: 24
   }
 })
 
@@ -144,14 +148,18 @@ const NowPlayingDrawer = ({
       isOpenToInitialOffset={isPlayBarShowing}
       animationStyle={DrawerAnimationStyle.SPRINGY}
       shouldBackgroundDim={false}
+      shouldAnimateShadow={false}
       drawerStyle={{ top: -1 * insets.top, overflow: 'visible' }}
       onPercentOpen={onDrawerPercentOpen}
       onPanResponderMove={onPanResponderMove}
     >
       <View style={styles.container}>
         <PlayBar onPress={onDrawerOpen} opacityAnim={playBarOpacityAnim} />
-        <AudioControls />
-        <ActionsBar />
+        <Logo opacityAnim={playBarOpacityAnim} />
+        <View style={styles.controls}>
+          <AudioControls />
+          <ActionsBar />
+        </View>
       </View>
     </Drawer>
   )

--- a/src/components/now-playing-drawer/PlayBar.tsx
+++ b/src/components/now-playing-drawer/PlayBar.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import {
   StyleSheet,
-  Text,
   TouchableOpacity,
   Animated,
   View,
@@ -12,6 +11,7 @@ import {
 import IconPause from 'app/assets/animations/iconPause.json'
 import IconPlay from 'app/assets/animations/iconPlay.json'
 import FavoriteButton from 'app/components/favorite-button'
+import Text from 'app/components/text'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
 import { Theme, ThemeColors, useThemeVariant } from 'app/utils/theme'
 
@@ -64,20 +64,17 @@ const createStyles = (themeColors: ThemeColors) =>
       flexDirection: 'row'
     },
     title: {
-      fontFamily: 'AvenirNextLTPro-Bold',
       color: themeColors.neutral,
       maxWidth: Dimensions.get('window').width / 3,
       fontSize: 12
     },
     separator: {
-      fontFamily: 'AvenirNextLTPro-Bold',
       color: themeColors.neutral,
       marginLeft: 4,
       marginRight: 4,
       fontSize: 16
     },
     artist: {
-      fontFamily: 'AvenirNextLTPro-Medium',
       color: themeColors.neutral,
       maxWidth: Dimensions.get('window').width / 4,
       fontSize: 12
@@ -145,11 +142,13 @@ export const PlayBar = ({ onPress, opacityAnim }: PlayBarProps) => {
         >
           <View style={styles.artwork} />
           <View style={styles.trackText}>
-            <Text numberOfLines={1} style={styles.title}>
+            <Text numberOfLines={1} weight='bold' style={styles.title}>
               Crazy
             </Text>
-            <Text style={styles.separator}>•</Text>
-            <Text numberOfLines={1} style={styles.artist}>
+            <Text weight='bold' style={styles.separator}>
+              •
+            </Text>
+            <Text numberOfLines={1} weight='medium' style={styles.artist}>
               Gnarles Barkley
             </Text>
           </View>

--- a/src/components/now-playing-drawer/PlayBar.tsx
+++ b/src/components/now-playing-drawer/PlayBar.tsx
@@ -1,22 +1,41 @@
 import React from 'react'
 
-import { View, StyleSheet, Text, TouchableOpacity } from 'react-native'
+import { StyleSheet, Text, TouchableOpacity, Animated } from 'react-native'
 
 const styles = StyleSheet.create({
-  container: {}
+  container: {
+    height: 46
+  }
 })
 
 type PlayBarProps = {
   onPress: () => void
+  /**
+   * Opacity animation to fade out play bar as
+   * the new playing drawer is dragged open.
+   */
+  opacityAnim: Animated.Value
 }
 
-const PlayBar = ({ onPress }: PlayBarProps) => {
+const PlayBar = ({ onPress, opacityAnim }: PlayBarProps) => {
   return (
-    <View style={styles.container}>
+    <Animated.View
+      style={[
+        styles.container,
+        {
+          opacity: opacityAnim.interpolate({
+            // Interpolate the animation such that the play bar fades out
+            // at 25% up the screen.
+            inputRange: [0, 0.75, 1],
+            outputRange: [0, 0, 1]
+          })
+        }
+      ]}
+    >
       <TouchableOpacity onPress={onPress}>
         <Text>Something is playing</Text>
       </TouchableOpacity>
-    </View>
+    </Animated.View>
   )
 }
 

--- a/src/components/now-playing-drawer/PlayBar.tsx
+++ b/src/components/now-playing-drawer/PlayBar.tsx
@@ -1,12 +1,88 @@
 import React from 'react'
 
-import { StyleSheet, Text, TouchableOpacity, Animated } from 'react-native'
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  Animated,
+  View,
+  Dimensions
+} from 'react-native'
 
-const styles = StyleSheet.create({
-  container: {
-    height: 46
-  }
-})
+import IconPause from 'app/assets/animations/iconPause.json'
+import IconPlay from 'app/assets/animations/iconPlay.json'
+import FavoriteButton from 'app/components/favorite-button'
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { Theme, ThemeColors, useThemeVariant } from 'app/utils/theme'
+
+import AnimatedButtonProvider from '../animated-button/AnimatedButtonProvider'
+
+import { TrackingBar } from './TrackingBar'
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    root: {
+      width: '100%',
+      height: 46,
+      alignItems: 'center'
+    },
+    container: {
+      height: '100%',
+      width: '100%',
+      paddingLeft: 12,
+      paddingRight: 12,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-start'
+    },
+    button: {},
+    playIcon: {
+      width: 32,
+      height: 32
+    },
+    icon: {
+      width: 28,
+      height: 28
+    },
+    trackInfo: {
+      height: '100%',
+      flexShrink: 1,
+      flexGrow: 1,
+      alignItems: 'center',
+      flexDirection: 'row'
+    },
+    artwork: {
+      marginLeft: 12,
+      height: 26,
+      width: 26,
+      backgroundColor: 'blue',
+      borderRadius: 2
+    },
+    trackText: {
+      alignItems: 'center',
+      marginLeft: 12,
+      flexDirection: 'row'
+    },
+    title: {
+      fontFamily: 'AvenirNextLTPro-Bold',
+      color: themeColors.neutral,
+      maxWidth: Dimensions.get('window').width / 3,
+      fontSize: 12
+    },
+    separator: {
+      fontFamily: 'AvenirNextLTPro-Bold',
+      color: themeColors.neutral,
+      marginLeft: 4,
+      marginRight: 4,
+      fontSize: 16
+    },
+    artist: {
+      fontFamily: 'AvenirNextLTPro-Medium',
+      color: themeColors.neutral,
+      maxWidth: Dimensions.get('window').width / 4,
+      fontSize: 12
+    }
+  })
 
 type PlayBarProps = {
   onPress: () => void
@@ -17,11 +93,38 @@ type PlayBarProps = {
   opacityAnim: Animated.Value
 }
 
-const PlayBar = ({ onPress, opacityAnim }: PlayBarProps) => {
+export const PlayBar = ({ onPress, opacityAnim }: PlayBarProps) => {
+  const styles = useThemedStyles(createStyles)
+  const themeVariant = useThemeVariant()
+  const isDarkMode = themeVariant === Theme.DARK
+
+  const renderFavoriteButton = () => {
+    return (
+      <FavoriteButton
+        onPress={() => {}}
+        style={styles.button}
+        wrapperStyle={styles.icon}
+      />
+    )
+  }
+
+  const renderPlayButton = () => {
+    return (
+      <AnimatedButtonProvider
+        isDarkMode={isDarkMode}
+        iconLightJSON={[IconPlay, IconPause]}
+        iconDarkJSON={[IconPlay, IconPause]}
+        onPress={() => {}}
+        style={styles.button}
+        wrapperStyle={styles.playIcon}
+      />
+    )
+  }
+
   return (
     <Animated.View
       style={[
-        styles.container,
+        styles.root,
         {
           opacity: opacityAnim.interpolate({
             // Interpolate the animation such that the play bar fades out
@@ -32,11 +135,27 @@ const PlayBar = ({ onPress, opacityAnim }: PlayBarProps) => {
         }
       ]}
     >
-      <TouchableOpacity onPress={onPress}>
-        <Text>Something is playing</Text>
-      </TouchableOpacity>
+      <TrackingBar percentComplete={50} opacityAnim={opacityAnim} />
+      <View style={styles.container}>
+        {renderFavoriteButton()}
+        <TouchableOpacity
+          activeOpacity={1}
+          style={styles.trackInfo}
+          onPress={onPress}
+        >
+          <View style={styles.artwork} />
+          <View style={styles.trackText}>
+            <Text numberOfLines={1} style={styles.title}>
+              Crazy
+            </Text>
+            <Text style={styles.separator}>•</Text>
+            <Text numberOfLines={1} style={styles.artist}>
+              Gnarles Barkley
+            </Text>
+          </View>
+        </TouchableOpacity>
+        {renderPlayButton()}
+      </View>
     </Animated.View>
   )
 }
-
-export default PlayBar

--- a/src/components/now-playing-drawer/TrackingBar.tsx
+++ b/src/components/now-playing-drawer/TrackingBar.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+
+import { Animated, StyleSheet, View } from 'react-native'
+import LinearGradient from 'react-native-linear-gradient'
+
+import { useThemedStyles } from 'app/hooks/useThemedStyles'
+import { ThemeColors, useThemeColors } from 'app/utils/theme'
+
+const createStyles = (themeColors: ThemeColors) =>
+  StyleSheet.create({
+    rail: {
+      height: 2,
+      width: '100%',
+      backgroundColor: themeColors.neutralLight7
+    },
+    tracker: {
+      height: 2,
+      backgroundColor: 'red'
+    }
+  })
+
+type TrackingBarProps = {
+  /**
+   * Percentage "complete" the tracker should render to be
+   * (i.e. song % completion).
+   */
+  percentComplete: number
+  /**
+   * Opacity animation that signals how "open" the now playing
+   * drawer is.
+   */
+  opacityAnim: Animated.Value
+}
+
+export const TrackingBar = ({
+  percentComplete,
+  opacityAnim
+}: TrackingBarProps) => {
+  const styles = useThemedStyles(createStyles)
+  const { primaryLight2, primaryDark2 } = useThemeColors()
+  return (
+    <Animated.View
+      style={[
+        styles.rail,
+        {
+          opacity: opacityAnim.interpolate({
+            // Interpolate the animation such that the tracker fades out
+            // at 5% up the screen.
+            // The tracker is important to fade away shortly after
+            // the now playing drawer is opened so that the drawer may
+            // animate in corner radius without showing at the same time
+            // as the tracker.
+            inputRange: [0, 0.95, 1],
+            outputRange: [0, 0, 1]
+          })
+        }
+      ]}
+    >
+      <View
+        style={[
+          styles.tracker,
+          {
+            width: `${percentComplete}%`
+          }
+        ]}
+      >
+        <LinearGradient
+          useAngle
+          angle={135}
+          colors={[primaryLight2, primaryDark2]}
+          style={{ flex: 1 }}
+        />
+      </View>
+    </Animated.View>
+  )
+}


### PR DESCRIPTION
### Description

Adds UI to now playing drawer for play bar / tracking bar (unconnected to audius-client in this PR).

The bar fades away and is replaced with an Audius logo as the drawer is swiped open.
Smaller updates:
- Animation config for now playing drawer
- Initial position / drawer height fix
- Updates drawer border opacity for parity with mobile web. Android still needs a bit of testing, probably. Using the new "Shadow" did not work with the drawer -- there might be a way to fix that.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Not in use yet

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

https://user-images.githubusercontent.com/2731362/150912216-e668e49d-b1dd-4a1f-aa4c-47d0260680da.mp4




### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
