### PR TITLE
Fix Btn underlay color

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -141,8 +141,9 @@ const Button = ({
   const { primaryDark1 } = useThemeColors()
   const { scale, handlePressIn, handlePressOut } = usePressScaleAnimation()
 
+  // If underlay is set to undefined, the button will turn black when pressed
   const underlay =
-    type === ButtonType.PRIMARY ? underlayColor || primaryDark1 : undefined
+    type === ButtonType.PRIMARY ? underlayColor || primaryDark1 : 'transparent'
 
   return (
     <Animated.View


### PR DESCRIPTION
### Description
TouchableHighlight underlay is only allowed to be of type `Color | undefined`
Initially it was set to null in this PR: https://github.com/AudiusProject/audius-mobile-client/commit/9103dd3d60d3aae84ad717a7ca7d08515031f6c6

Then it was set to undefined in this PR because it was not type correct, but this caused the background to turn to black.
Ref: https://github.com/AudiusProject/audius-mobile-client/pull/224

Setting it to `transparent` does what setting it to null initially did. This affects several challenge btns and the share btn for collectibles

Fixes AUD-1388

### Dragons
none

### How Has This Been Tested?
Ran locally with light and dark modes

### How will this change be monitored?
