### PR TITLE
Add makeStyles pattern

### DIFF
--- a/src/styles/makeStyles.ts
+++ b/src/styles/makeStyles.ts
@@ -1,0 +1,27 @@
+import { useContext } from 'react'
+
+import { StyleSheet, TextStyle, ViewStyle, ImageStyle } from 'react-native'
+
+import { ThemeContext } from '../components/theme/ThemeContext'
+import { ThemeColors, useThemeColors } from '../utils/theme'
+
+import { typography } from './typography'
+
+type Theme = { palette: ThemeColors; typography: typeof typography }
+
+type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle }
+
+type Styles<T extends NamedStyles<T>> = (theme: Theme) => T
+
+export const makeStyles = <T extends NamedStyles<T>>(styles: Styles<T>) => {
+  const useStyles = () => {
+    const { getTheme } = useContext(ThemeContext)
+    const themeMode = getTheme()
+    const themeColors = useThemeColors()
+    const palette = { mode: themeMode, ...themeColors }
+    const theme: Theme = { palette, typography }
+    const styleProps = styles(theme)
+    return StyleSheet.create(styleProps)
+  }
+  return useStyles
+}

--- a/src/styles/makeStyles.ts
+++ b/src/styles/makeStyles.ts
@@ -5,21 +5,28 @@ import { StyleSheet, TextStyle, ViewStyle, ImageStyle } from 'react-native'
 import { ThemeContext } from '../components/theme/ThemeContext'
 import { ThemeColors, useThemeColors } from '../utils/theme'
 
+import { spacing } from './spacing'
 import { typography } from './typography'
 
-type Theme = { palette: ThemeColors; typography: typeof typography }
+type Theme = {
+  palette: ThemeColors
+  typography: typeof typography
+  spacing: typeof spacing
+}
 
 type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle }
 
-type Styles<T extends NamedStyles<T>> = (theme: Theme) => T
+type Styles<T extends NamedStyles<T>> = (theme: Theme) => T | NamedStyles<T>
 
-export const makeStyles = <T extends NamedStyles<T>>(styles: Styles<T>) => {
-  const useStyles = () => {
+export const makeStyles = <T extends NamedStyles<T> | NamedStyles<any>>(
+  styles: Styles<T>
+) => {
+  const useStyles = (): T => {
     const { getTheme } = useContext(ThemeContext)
     const themeMode = getTheme()
     const themeColors = useThemeColors()
     const palette = { mode: themeMode, ...themeColors }
-    const theme: Theme = { palette, typography }
+    const theme: Theme = { palette, typography, spacing }
     const namedStyles = styles(theme)
     return StyleSheet.create(namedStyles)
   }

--- a/src/styles/makeStyles.ts
+++ b/src/styles/makeStyles.ts
@@ -20,8 +20,8 @@ export const makeStyles = <T extends NamedStyles<T>>(styles: Styles<T>) => {
     const themeColors = useThemeColors()
     const palette = { mode: themeMode, ...themeColors }
     const theme: Theme = { palette, typography }
-    const styleProps = styles(theme)
-    return StyleSheet.create(styleProps)
+    const namedStyles = styles(theme)
+    return StyleSheet.create(namedStyles)
   }
   return useStyles
 }

--- a/src/styles/spacing.ts
+++ b/src/styles/spacing.ts
@@ -1,0 +1,1 @@
+export const spacing = (space: number) => space * 4

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -14,3 +14,11 @@ export const fontByWeight = {
 export const font = (weight: keyof typeof fontByWeight): TextStyle => ({
   fontFamily: fontByWeight[weight]
 })
+
+export const typography: Record<'h1', TextStyle> = {
+  h1: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    fontFamily: fontByWeight.bold
+  }
+}

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,6 +1,16 @@
 import { TextStyle } from 'react-native'
 
-export const fontByWeight = {
+type FontWeight =
+  | 'heavy'
+  | 'bold'
+  | 'demiBold'
+  | 'medium'
+  | 'regular'
+  | 'light'
+  | 'thin'
+  | 'ultraLight'
+
+export const fontByWeight: Record<FontWeight, string> = {
   heavy: 'AvenirNextLTPro-Heavy',
   bold: 'AvenirNextLTPro-Bold',
   demiBold: 'AvenirNextLTPro-DemiBold',
@@ -11,14 +21,25 @@ export const fontByWeight = {
   ultraLight: 'AvenirNextLTPro-UltLt'
 }
 
-export const font = (weight: keyof typeof fontByWeight): TextStyle => ({
+export const font = (weight: FontWeight): TextStyle => ({
   fontFamily: fontByWeight[weight]
 })
 
-export const typography: Record<'h1', TextStyle> = {
+export const typography = {
   h1: {
     fontSize: 18,
-    fontWeight: 'bold',
-    fontFamily: fontByWeight.bold
-  }
+    fontFamily: fontByWeight.bold,
+    marginBottom: 18 * 0.35
+  },
+  h2: {
+    fontSize: 14,
+    fontFamily: fontByWeight.medium,
+    marginBottom: 14 * 0.35
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: fontByWeight.medium,
+    marginBottom: 14 * 0.35
+  },
+  fontByWeight
 }


### PR DESCRIPTION
### Description

Style pattern that tries to unify and extend our theme use when creating styles

Usage:
```tsx
const useStyles = makeStyles(theme => ({
  headerExample: {
    ...theme.typography.h1,
    color: theme.palette.neutral
  },
})

const ExampleComponent = () => {
  const styles = useStyles()
  
  return (
    <Text style={styles.headerExample}>Example Header</Text>
  )
}
```

Pattern draws inspiration from material-ui!

Future versions can allow props to be passed to useStyles to do more custom styling, example:
```tsx
const useStyles = makeStyles((theme, props) => ({
  exampleStyle: {
     color: props.something ? theme.palette.primary : theme.palette.secondary
   }
})

const ExampleComponent = ({something}) => {
  const styles = useStyles({something})
  
  return (
    <Text style={styles.exampleStyle}>Example Text</Text>
  )
}
```

Currently, `palette` and `typography` are the only things currently in our theme, but we can easily add more, like spacing, zIndex, breakpoints, transitions, etc...