### PR TITLE
Update DynamicImage styles, rename image to source

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 
-import DynamicImage from 'app/components/dynamic-image'
+import { DynamicImage } from 'app/components/core'
 import UserBadges from 'app/components/user-badges/UserBadges'
 import { useCollectionCoverArt } from 'app/hooks/useCollectionCoverArt'
 import { ThemeColors, useThemedStyles } from 'app/hooks/useThemedStyles'
@@ -100,7 +100,7 @@ const CardImage = ({ id, type, imageSize }: CardImageProps) => {
     type === 'user' ? useUserProfilePicture : useCollectionCoverArt
   const image = useImage(id, imageSize, SquareSizes.SIZE_150_BY_150)
 
-  return <DynamicImage image={{ uri: image }} />
+  return <DynamicImage source={{ uri: image }} />
 }
 
 export const Card = ({

--- a/src/components/core/DynamicImage/DynamicImage.tsx
+++ b/src/components/core/DynamicImage/DynamicImage.tsx
@@ -1,4 +1,11 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  memo,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import transparentPlaceholderImg from 'audius-client/src/common/assets/image/1x1-transparent.png'
 import useInstanceVar from 'audius-client/src/common/hooks/useInstanceVar'
@@ -32,6 +39,8 @@ export type DynamicImageProps = {
   immediate?: boolean
   // Whether or not to use the default placeholder
   usePlaceholder?: boolean
+  // overlays rendered above image
+  children?: ReactNode
 }
 
 const styles = StyleSheet.create({
@@ -101,7 +110,8 @@ const DynamicImage = ({
   style,
   styles: stylesProp,
   immediate,
-  usePlaceholder = true
+  usePlaceholder = true,
+  children
 }: DynamicImageProps) => {
   const [firstSize, setFirstSize] = useState(0)
   const [secondSize, setSecondSize] = useState(0)
@@ -197,6 +207,7 @@ const DynamicImage = ({
           usePlaceholder={usePlaceholder}
         />
       </Animated.View>
+      {children}
     </View>
   )
 }

--- a/src/components/core/DynamicImage/DynamicImage.tsx
+++ b/src/components/core/DynamicImage/DynamicImage.tsx
@@ -10,18 +10,24 @@ import {
   ImageSourcePropType,
   ImageStyle,
   ImageURISource,
+  LayoutChangeEvent,
   StyleProp,
   StyleSheet,
-  View
+  View,
+  ViewStyle
 } from 'react-native'
 
 import { ImageSkeleton } from 'app/components/image-skeleton'
 
 export type DynamicImageProps = {
   // Image source
-  image?: ImageSourcePropType
-  // Style to apply to the image itself
-  style?: StyleProp<ImageStyle>
+  source?: ImageSourcePropType
+  styles?: {
+    root?: ViewStyle
+    imageContainer?: ViewStyle
+    image?: StyleProp<ImageStyle>
+  }
+  style?: ViewStyle
   // Whether or not to immediately animate
   immediate?: boolean
   // Whether or not to use the default placeholder
@@ -29,7 +35,7 @@ export type DynamicImageProps = {
 }
 
 const styles = StyleSheet.create({
-  image: {
+  imageContainer: {
     position: 'absolute',
     top: 0,
     right: 0,
@@ -65,24 +71,35 @@ const isImageEqual = (
   return false
 }
 
-const ImageWithPlaceholder = ({ usePlaceholder, image, style }) => {
-  if (image) {
-    return <Image source={image} style={style} />
+type ImageWithPlaceholderProps = {
+  usePlaceholder: boolean
+  source?: ImageSourcePropType
+  style: StyleProp<ImageStyle>
+}
+
+const ImageWithPlaceholder = ({
+  usePlaceholder,
+  source,
+  style
+}: ImageWithPlaceholderProps) => {
+  if (source) {
+    return <Image source={source} style={style} />
   }
 
   if (usePlaceholder) {
-    return <ImageSkeleton styles={{ root: style }} />
+    return <ImageSkeleton styles={{ root: style as ViewStyle }} />
   }
 
-  return <Image source={transparentPlaceholderImg} />
+  return <Image source={transparentPlaceholderImg} style={style} />
 }
 
 /**
  * A dynamic image that transitions between changes to the `image` prop.
  */
 const DynamicImage = ({
-  image,
+  source,
   style,
+  styles: stylesProp,
   immediate,
   usePlaceholder = true
 }: DynamicImageProps) => {
@@ -114,20 +131,20 @@ const DynamicImage = ({
   useEffect(() => {
     // Skip animation for subsequent loads where the image hasn't changed
     const previousImage = getPrevImage()
-    if (previousImage !== null && isImageEqual(previousImage, image)) {
+    if (previousImage !== null && isImageEqual(previousImage, source)) {
       return
     }
 
-    setPrevImage(image ?? null)
+    setPrevImage(source ?? null)
 
     if (isFirstImageActive) {
       setIsFirstImageActive(false)
-      setFirstImage(image)
+      setFirstImage(source)
       animateTo(firstOpacity, 1)
       animateTo(secondOpacity, 0)
     } else {
       setIsFirstImageActive(true)
-      setSecondImage(image)
+      setSecondImage(source)
       animateTo(firstOpacity, 0)
       animateTo(secondOpacity, 1)
     }
@@ -135,35 +152,48 @@ const DynamicImage = ({
     animateTo,
     firstOpacity,
     getPrevImage,
-    image,
+    source,
     isFirstImageActive,
     secondOpacity,
     setIsFirstImageActive,
     setPrevImage
   ])
 
+  const handleSetFirstSize = useCallback((event: LayoutChangeEvent) => {
+    setFirstSize(event.nativeEvent.layout.width)
+  }, [])
+
+  const handleSetSecondSize = useCallback((event: LayoutChangeEvent) => {
+    setSecondSize(event.nativeEvent.layout.width)
+  }, [])
+
   return (
-    <View>
+    <View style={[style, stylesProp?.root]}>
       <Animated.View
-        style={[styles.image, { opacity: firstOpacity }]}
-        onLayout={e => setFirstSize(e.nativeEvent.layout.width)}
+        style={[
+          stylesProp?.imageContainer,
+          styles.imageContainer,
+          { opacity: firstOpacity }
+        ]}
+        onLayout={handleSetFirstSize}
       >
         <ImageWithPlaceholder
-          image={firstImage}
-          style={[{ width: firstSize, height: firstSize }, style]}
+          source={firstImage}
+          style={[{ width: firstSize, height: firstSize }, stylesProp?.image]}
           usePlaceholder={usePlaceholder}
         />
       </Animated.View>
       <Animated.View
         style={[
-          styles.image,
+          stylesProp?.imageContainer,
+          styles.imageContainer,
           { opacity: secondOpacity, zIndex: isFirstImageActive ? -1 : 0 }
         ]}
-        onLayout={e => setSecondSize(e.nativeEvent.layout.width)}
+        onLayout={handleSetSecondSize}
       >
         <ImageWithPlaceholder
-          image={secondImage}
-          style={[{ width: secondSize, height: secondSize }, style]}
+          source={secondImage}
+          style={[{ width: secondSize, height: secondSize }, stylesProp?.image]}
           usePlaceholder={usePlaceholder}
         />
       </Animated.View>
@@ -171,4 +201,6 @@ const DynamicImage = ({
   )
 }
 
-export default memo(DynamicImage)
+const MemoizedDynamicImage = memo(DynamicImage)
+
+export default MemoizedDynamicImage

--- a/src/components/core/DynamicImage/DynamicImage.tsx
+++ b/src/components/core/DynamicImage/DynamicImage.tsx
@@ -25,16 +25,17 @@ import {
 } from 'react-native'
 
 import { ImageSkeleton } from 'app/components/image-skeleton'
+import { StylesProp } from 'app/styles'
 
 export type DynamicImageProps = {
   // Image source
   source?: ImageSourcePropType
-  styles?: {
-    root?: ViewStyle
-    imageContainer?: ViewStyle
-    image?: StyleProp<ImageStyle>
-  }
-  style?: ViewStyle
+  styles?: StylesProp<{
+    root: ViewStyle
+    imageContainer: ViewStyle
+    image: ImageStyle
+  }>
+  style?: StyleProp<ViewStyle>
   // Whether or not to immediately animate
   immediate?: boolean
   // Whether or not to use the default placeholder

--- a/src/components/core/DynamicImage/index.ts
+++ b/src/components/core/DynamicImage/index.ts
@@ -1,0 +1,1 @@
+export { default as DynamicImage } from './DynamicImage'

--- a/src/components/core/index.ts
+++ b/src/components/core/index.ts
@@ -1,1 +1,2 @@
 export * from './Tile'
+export * from './DynamicImage'

--- a/src/components/dynamic-image/index.ts
+++ b/src/components/dynamic-image/index.ts
@@ -1,1 +1,0 @@
-export { default } from './DynamicImage'

--- a/src/components/now-playing-drawer/Artwork.tsx
+++ b/src/components/now-playing-drawer/Artwork.tsx
@@ -69,7 +69,7 @@ export const Artwork = ({ track }: ArtworkProps) => {
         startColor={shadowColor}
       >
         <View style={styles.image}>
-          <DynamicImage usePlaceholder source={{ uri: image }} />
+          <DynamicImage source={{ uri: image }} />
         </View>
       </Shadow>
     </View>

--- a/src/components/now-playing-drawer/Artwork.tsx
+++ b/src/components/now-playing-drawer/Artwork.tsx
@@ -6,7 +6,7 @@ import { getDominantColorsByTrack } from 'audius-client/src/common/store/average
 import { Dimensions, StyleSheet, View } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 
-import DynamicImage from 'app/components/dynamic-image'
+import { DynamicImage } from 'app/components/core'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
 import { useTrackCoverArt } from 'app/hooks/useTrackCoverArt'
@@ -69,7 +69,7 @@ export const Artwork = ({ track }: ArtworkProps) => {
         startColor={shadowColor}
       >
         <View style={styles.image}>
-          <DynamicImage usePlaceholder image={{ uri: image }} />
+          <DynamicImage usePlaceholder source={{ uri: image }} />
         </View>
       </Shadow>
     </View>

--- a/src/components/now-playing-drawer/PlayBar.tsx
+++ b/src/components/now-playing-drawer/PlayBar.tsx
@@ -19,7 +19,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import IconPause from 'app/assets/animations/iconPause.json'
 import IconPlay from 'app/assets/animations/iconPlay.json'
-import DynamicImage from 'app/components/dynamic-image'
+import { DynamicImage } from 'app/components/core'
 import FavoriteButton from 'app/components/favorite-button'
 import Text from 'app/components/text'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
@@ -115,7 +115,7 @@ const PlayBarArtwork = ({ track }: { track: Track }) => {
     track._cover_art_sizes,
     SquareSizes.SIZE_150_BY_150
   )
-  return <DynamicImage image={{ uri: image }} />
+  return <DynamicImage source={{ uri: image }} />
 }
 
 export const PlayBar = ({

--- a/src/components/track-tile/TrackTileArt.tsx
+++ b/src/components/track-tile/TrackTileArt.tsx
@@ -8,7 +8,7 @@ import { Remix } from 'audius-client/src/common/models/Track'
 import { ImageStyle, StyleProp, View, ViewStyle } from 'react-native'
 
 import CoSign, { Size } from 'app/components/co-sign'
-import DynamicImage from 'app/components/dynamic-image'
+import { DynamicImage } from 'app/components/core'
 import { useCollectionCoverArt } from 'app/hooks/useCollectionCoverArt'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
 import { useTrackCoverArt } from 'app/hooks/useTrackCoverArt'
@@ -39,7 +39,10 @@ export const TrackTileArt = ({
   useLoadImageWithTimeout(image, onLoad)
 
   const imageElement = (
-    <DynamicImage image={{ uri: image }} style={styles.image as ImageStyle} />
+    <DynamicImage
+      source={{ uri: image }}
+      styles={{ image: styles.image as ImageStyle }}
+    />
   )
 
   return coSign ? (

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -3,3 +3,5 @@
  */
 export * from './flex'
 export * from './typography'
+export * from './makeStyles'
+export * from './types'

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1,0 +1,3 @@
+import { StyleProp } from 'react-native'
+
+export type StylesProp<T> = { [K in keyof T]?: StyleProp<T[K]> }


### PR DESCRIPTION
### Description
- Re-routes the `style` prop to the root container
- Adds `styles` prop which includes entries for the `root`, `imageContainer`, and `image` sub elements
- Renames `image` prop to `source` to mimic the react-native Image props
- Adds `children` prop, to allow overlays
- Minor perf improvements with `useCallback`
- Moves component to "core" directory
