### PR TITLE
[AUD-1409] Add profile-page tracks and reposts tabs

### DIFF
--- a/src/components/lineup/Lineup.tsx
+++ b/src/components/lineup/Lineup.tsx
@@ -227,6 +227,7 @@ export const Lineup = ({
         // TODO: Playlist tile
       }
     }
+    return null
   }
 
   // Calculate the sections of data to provide to SectionList

--- a/src/components/lineup/Lineup.tsx
+++ b/src/components/lineup/Lineup.tsx
@@ -191,37 +191,41 @@ export const Lineup = ({
     index: number
     item: LineupItem | LoadingLineupItem
   }) => {
-    if (item._loading) {
-      return (
-        <View style={styles.item}>
-          <TrackTileSkeleton />
-        </View>
-      )
-    }
-
-    if (item.kind === Kind.TRACKS || item.track_id) {
-      // Render a track tile if the kind tracks or there's a track id present
-
-      if (item._marked_deleted) {
-        return null
+    if ('_loading' in item) {
+      if (item._loading) {
+        return (
+          <View style={styles.item}>
+            <TrackTileSkeleton />
+          </View>
+        )
       }
-
-      return (
-        <View style={styles.item}>
-          <TrackTile
-            {...item}
-            index={index}
-            isTrending={isTrending}
-            showArtistPick={showLeadingElementArtistPick && !!leadingElementId}
-            showRankIcon={index < rankIconCount}
-            togglePlay={togglePlay}
-            uid={item.uid}
-          />
-        </View>
-      )
     } else {
-      return null
-      // TODO: Playlist tile
+      if (item.kind === Kind.TRACKS || item.track_id) {
+        // Render a track tile if the kind tracks or there's a track id present
+
+        if (item._marked_deleted) {
+          return null
+        }
+
+        return (
+          <View style={styles.item}>
+            <TrackTile
+              {...item}
+              index={index}
+              isTrending={isTrending}
+              showArtistPick={
+                showLeadingElementArtistPick && !!leadingElementId
+              }
+              showRankIcon={index < rankIconCount}
+              togglePlay={togglePlay}
+              uid={item.uid}
+            />
+          </View>
+        )
+      } else {
+        return null
+        // TODO: Playlist tile
+      }
     }
   }
 

--- a/src/components/lineup/types.ts
+++ b/src/components/lineup/types.ts
@@ -11,7 +11,6 @@ export enum LineupVariant {
 }
 
 export type LineupItem = {
-  _loading?: false
   id: ID
   kind: Kind
   track_id?: ID

--- a/src/components/lineup/types.ts
+++ b/src/components/lineup/types.ts
@@ -11,7 +11,7 @@ export enum LineupVariant {
 }
 
 export type LineupItem = {
-  _loading: false
+  _loading?: false
   id: ID
   kind: Kind
   track_id?: ID

--- a/src/components/now-playing-drawer/Artwork.tsx
+++ b/src/components/now-playing-drawer/Artwork.tsx
@@ -54,10 +54,13 @@ export const Artwork = ({ track }: ArtworkProps) => {
       track
     })
   )
+
+  let shadowColor = 'rgba(0,0,0,0)'
   const dominantColor = dominantColors ? dominantColors[0] : null
-  const shadowColor = dominantColor
-    ? `rgba(${dominantColor.r},${dominantColor.g},${dominantColor.b},0.1)`
-    : 'rgba(0,0,0,0)'
+  if (dominantColor) {
+    const { r, g, b } = dominantColor
+    shadowColor = `rgba(${r.toFixed()},${g.toFixed()},${b.toFixed()},0.1)`
+  }
 
   return (
     <View style={styles.root}>

--- a/src/screens/profile-screen/EmptyTab.tsx
+++ b/src/screens/profile-screen/EmptyTab.tsx
@@ -13,7 +13,6 @@ const useStyles = makeStyles(({ spacing }) => ({
     paddingHorizontal: spacing(6)
   },
   emptyTabContent: {
-    display: 'flex',
     alignItems: 'center'
   }
 }))

--- a/src/screens/profile-screen/EmptyTab.tsx
+++ b/src/screens/profile-screen/EmptyTab.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react'
+
+import { Tile } from 'app/components/core'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ spacing }) => ({
+  emptyTabRoot: {
+    marginVertical: spacing(2),
+    marginHorizontal: spacing(3)
+  },
+  emptyTab: {
+    paddingVertical: spacing(8),
+    paddingHorizontal: spacing(6)
+  },
+  emptyTabContent: {
+    display: 'flex',
+    alignItems: 'center'
+  }
+}))
+
+type EmptyTabProps = {
+  children: ReactNode
+}
+
+export const EmptyTab = ({ children }: EmptyTabProps) => {
+  const styles = useStyles()
+  return (
+    <Tile
+      styles={{
+        root: styles.emptyTabRoot,
+        tile: styles.emptyTab,
+        content: styles.emptyTabContent
+      }}
+    >
+      {children}
+    </Tile>
+  )
+}

--- a/src/screens/profile-screen/RepostsTab.tsx
+++ b/src/screens/profile-screen/RepostsTab.tsx
@@ -11,6 +11,10 @@ import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { EmptyTab } from './EmptyTab'
 import { getProfile } from './selectors'
 
+const messages = {
+  emptyTabText: "You haven't reposted anything yet"
+}
+
 export const RepostsTab = () => {
   const { profile } = useSelectorWeb(getProfile)
   const lineup = useSelectorWeb(getProfileFeedLineup)
@@ -32,7 +36,7 @@ export const RepostsTab = () => {
   if (profile.repost_count === 0) {
     return (
       <EmptyTab>
-        <Text>{"You haven't reposted anything yet"}</Text>
+        <Text>{messages.emptyTabText}</Text>
       </EmptyTab>
     )
   }

--- a/src/screens/profile-screen/RepostsTab.tsx
+++ b/src/screens/profile-screen/RepostsTab.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react'
+
+import { feedActions } from 'audius-client/src/common/store/pages/profile/lineups/feed/actions'
+import { getProfileFeedLineup } from 'audius-client/src/common/store/pages/profile/selectors'
+import { Text } from 'react-native'
+
+import { Lineup } from 'app/components/lineup'
+import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+
+import { EmptyTab } from './EmptyTab'
+import { getProfile } from './selectors'
+
+export const RepostsTab = () => {
+  const { profile } = useSelectorWeb(getProfile)
+  const lineup = useSelectorWeb(getProfileFeedLineup)
+  const dispatchWeb = useDispatchWeb()
+
+  const handlePlayTrack = useCallback(
+    (uid: string) => {
+      dispatchWeb(feedActions.play(uid))
+    },
+    [dispatchWeb]
+  )
+
+  const handlePauseTrack = useCallback(() => {
+    dispatchWeb(feedActions.pause())
+  }, [dispatchWeb])
+
+  if (!profile) return null
+
+  if (profile.repost_count === 0) {
+    return (
+      <EmptyTab>
+        <Text>{"You haven't reposted anything yet"}</Text>
+      </EmptyTab>
+    )
+  }
+
+  return (
+    <Lineup
+      actions={feedActions}
+      lineup={lineup as any}
+      playTrack={handlePlayTrack}
+      pauseTrack={handlePauseTrack}
+    />
+  )
+}

--- a/src/screens/profile-screen/RepostsTab.tsx
+++ b/src/screens/profile-screen/RepostsTab.tsx
@@ -44,7 +44,7 @@ export const RepostsTab = () => {
   return (
     <Lineup
       actions={feedActions}
-      lineup={lineup as any}
+      lineup={lineup}
       playTrack={handlePlayTrack}
       pauseTrack={handlePauseTrack}
     />

--- a/src/screens/profile-screen/TracksTab.tsx
+++ b/src/screens/profile-screen/TracksTab.tsx
@@ -11,6 +11,10 @@ import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { EmptyTab } from './EmptyTab'
 import { getProfile } from './selectors'
 
+const messages = {
+  emptyTabText: "You haven't created any tracks yet"
+}
+
 export const TracksTab = () => {
   const { profile } = useSelectorWeb(getProfile)
   const lineup = useSelectorWeb(getProfileTracksLineup)
@@ -32,7 +36,7 @@ export const TracksTab = () => {
   if (profile.track_count === 0) {
     return (
       <EmptyTab>
-        <Text>{"You haven't created any tracks yet"}</Text>
+        <Text>{messages.emptyTabText}</Text>
       </EmptyTab>
     )
   }
@@ -40,7 +44,7 @@ export const TracksTab = () => {
   return (
     <Lineup
       actions={tracksActions}
-      lineup={lineup as any}
+      lineup={lineup}
       playTrack={handlePlayTrack}
       pauseTrack={handlePauseTrack}
     />

--- a/src/screens/profile-screen/TracksTab.tsx
+++ b/src/screens/profile-screen/TracksTab.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react'
+
+import { tracksActions } from 'audius-client/src/common/store/pages/profile/lineups/tracks/actions'
+import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/profile/selectors'
+import { Text } from 'react-native'
+
+import { Lineup } from 'app/components/lineup'
+import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+
+import { EmptyTab } from './EmptyTab'
+import { getProfile } from './selectors'
+
+export const TracksTab = () => {
+  const { profile } = useSelectorWeb(getProfile)
+  const lineup = useSelectorWeb(getProfileTracksLineup)
+  const dispatchWeb = useDispatchWeb()
+
+  const handlePlayTrack = useCallback(
+    (uid: string) => {
+      dispatchWeb(tracksActions.play(uid))
+    },
+    [dispatchWeb]
+  )
+
+  const handlePauseTrack = useCallback(() => {
+    dispatchWeb(tracksActions.pause())
+  }, [dispatchWeb])
+
+  if (!profile) return null
+
+  if (profile.track_count === 0) {
+    return (
+      <EmptyTab>
+        <Text>{"You haven't created any tracks yet"}</Text>
+      </EmptyTab>
+    )
+  }
+
+  return (
+    <Lineup
+      actions={tracksActions}
+      lineup={lineup as any}
+      playTrack={handlePlayTrack}
+      pauseTrack={handlePauseTrack}
+    />
+  )
+}


### PR DESCRIPTION
### Description

Adds tracks and reposts tabs, leveraging the Lineup component

### Dragons

There was a weird bug in `Artwork.tsx` where the dominant color values where not integers and instead something like 120.0000039, which caused a rendering error for the shadow component. Added a workaround using let syntax, curious if folks like that approach vs a purely functional one