### PR TITLE
Refactor Card to use Tile, update Tile shadows

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -71,16 +71,18 @@ const CardImage = ({ id, type, imageSize }: CardImageProps) => {
   return <DynamicImage source={{ uri: image }} />
 }
 
-export const Card = ({
-  id,
-  imageSize,
-  onPress,
-  primaryText,
-  secondaryText,
-  style,
-  type = 'user',
-  user
-}: CardProps) => {
+export const Card = (props: CardProps) => {
+  const {
+    id,
+    imageSize,
+    onPress,
+    primaryText,
+    secondaryText,
+    style,
+    type = 'user',
+    user
+  } = props
+
   const styles = useStyles()
 
   return (
@@ -97,16 +99,7 @@ export const Card = ({
         <Text numberOfLines={1} style={styles.primaryText}>
           {primaryText}
           {type === 'user' ? (
-            <UserBadges
-              user={{
-                balance: user.balance,
-                associated_wallets_balance: user.associated_wallets_balance,
-                name: user.name,
-                is_verified: user.is_verified
-              }}
-              badgeSize={12}
-              hideName
-            />
+            <UserBadges user={user} badgeSize={12} hideName />
           ) : null}
         </Text>
         <Text numberOfLines={1} style={styles.secondaryText}>

--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -4,79 +4,47 @@ import {
   SquareSizes
 } from 'audius-client/src/common/models/ImageSizes'
 import { User } from 'audius-client/src/common/models/User'
-import {
-  StyleProp,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  ViewStyle
-} from 'react-native'
-import { Shadow } from 'react-native-shadow-2'
+import { StyleProp, Text, View, ViewStyle } from 'react-native'
 
-import { DynamicImage } from 'app/components/core'
+import { DynamicImage, Tile } from 'app/components/core'
 import UserBadges from 'app/components/user-badges/UserBadges'
 import { useCollectionCoverArt } from 'app/hooks/useCollectionCoverArt'
-import { ThemeColors, useThemedStyles } from 'app/hooks/useThemedStyles'
 import { useUserProfilePicture } from 'app/hooks/useUserProfilePicture'
 import { ID } from 'app/store/notifications/types'
-import { font } from 'app/styles'
+import { makeStyles } from 'app/styles'
 
 export type CardType = 'user' | 'collection'
 
-const createStyles = (themeColors: ThemeColors) =>
-  StyleSheet.create({
-    cardContainer: {
-      backgroundColor: themeColors.white,
-      borderRadius: 8,
-      overflow: 'hidden',
-      width: '100%',
-      minWidth: 172,
-      maxWidth: 190
-    },
-    cardContent: {
-      display: 'flex',
-      paddingHorizontal: 8
-    },
-    imgContainer: {
-      paddingTop: 8,
-      paddingHorizontal: 8
-    },
-    cardImg: {
-      position: 'relative',
-      backgroundColor: '#ddd',
-      borderRadius: 6,
-      overflow: 'hidden',
-      paddingBottom: '100%',
-      width: '100%'
-    },
-    userImg: {
-      borderRadius: 1000
-    },
-    textContainer: {
-      paddingVertical: 4
-    },
-    primaryText: {
-      ...font('bold'),
-      color: themeColors.neutral,
-      fontSize: 14,
-      lineHeight: 18,
-      marginBottom: 2,
-      maxWidth: 160,
-      overflow: 'hidden',
-      textAlign: 'center'
-    },
-    secondaryText: {
-      ...font('medium'),
-      color: themeColors.neutral,
-      fontSize: 12,
-      lineHeight: 18,
-      marginBottom: 2,
-      overflow: 'hidden',
-      textAlign: 'center',
-      width: '100%'
-    }
-  })
+const useStyles = makeStyles(({ palette, typography, spacing }) => ({
+  cardContent: {
+    paddingHorizontal: spacing(2)
+  },
+  imgContainer: {
+    padding: spacing(2)
+  },
+  cardImg: {
+    backgroundColor: '#ddd',
+    borderRadius: 6,
+    overflow: 'hidden',
+    paddingBottom: '100%'
+  },
+  userImg: {
+    borderRadius: 1000
+  },
+  textContainer: {
+    paddingVertical: spacing(1)
+  },
+  primaryText: {
+    ...typography.h2,
+    color: palette.neutral,
+    textAlign: 'center'
+  },
+  secondaryText: {
+    ...typography.body2,
+    color: palette.neutral,
+    textAlign: 'center'
+  }
+}))
 
 export type CardProps = {
   id: ID
@@ -113,51 +81,38 @@ export const Card = ({
   type = 'user',
   user
 }: CardProps) => {
-  const styles = useThemedStyles(createStyles)
+  const styles = useStyles()
 
   return (
-    <View style={style}>
-      <Shadow
-        offset={[0, 2]}
-        viewStyle={{ alignSelf: 'stretch' }}
-        distance={5}
-        startColor='rgba(133,129,153,0.11)'
-      >
-        <View style={styles.cardContainer}>
-          <TouchableOpacity onPress={onPress}>
-            <View style={styles.cardContent}>
-              <View style={styles.imgContainer}>
-                <View
-                  style={[styles.cardImg, type === 'user' && styles.userImg]}
-                >
-                  <CardImage imageSize={imageSize} type={type} id={id} />
-                </View>
-              </View>
-              <View style={styles.textContainer}>
-                <Text numberOfLines={1} style={styles.primaryText}>
-                  {primaryText}
-                  {type === 'user' ? (
-                    <UserBadges
-                      user={{
-                        balance: user.balance,
-                        associated_wallets_balance:
-                          user.associated_wallets_balance,
-                        name: user.name,
-                        is_verified: user.is_verified
-                      }}
-                      badgeSize={12}
-                      hideName
-                    />
-                  ) : null}
-                </Text>
-                <Text numberOfLines={1} style={styles.secondaryText}>
-                  {secondaryText}
-                </Text>
-              </View>
-            </View>
-          </TouchableOpacity>
+    <Tile
+      onPress={onPress}
+      styles={{ root: style, content: styles.cardContent }}
+    >
+      <View style={styles.imgContainer}>
+        <View style={[styles.cardImg, type === 'user' && styles.userImg]}>
+          <CardImage imageSize={imageSize} type={type} id={id} />
         </View>
-      </Shadow>
-    </View>
+      </View>
+      <View style={styles.textContainer}>
+        <Text numberOfLines={1} style={styles.primaryText}>
+          {primaryText}
+          {type === 'user' ? (
+            <UserBadges
+              user={{
+                balance: user.balance,
+                associated_wallets_balance: user.associated_wallets_balance,
+                name: user.name,
+                is_verified: user.is_verified
+              }}
+              badgeSize={12}
+              hideName
+            />
+          ) : null}
+        </Text>
+        <Text numberOfLines={1} style={styles.secondaryText}>
+          {secondaryText}
+        </Text>
+      </View>
+    </Tile>
   )
 }

--- a/src/components/collection-list/CollectionList.tsx
+++ b/src/components/collection-list/CollectionList.tsx
@@ -18,9 +18,7 @@ export const CollectionList = (props: CollectionListProps) => {
   return (
     <CardList
       data={collection}
-      renderItem={({ item, style }) => (
-        <CollectionCard collection={item} style={style} />
-      )}
+      renderItem={({ item }) => <CollectionCard collection={item} />}
       {...other}
     />
   )

--- a/src/components/core/CardList.tsx
+++ b/src/components/core/CardList.tsx
@@ -1,25 +1,16 @@
-import { ReactElement, useCallback } from 'react'
+import { useCallback } from 'react'
 
 import {
   FlatList,
   FlatListProps,
-  ListRenderItemInfo,
-  ViewStyle,
-  StyleProp,
   ListRenderItem,
-  Text
+  Text,
+  View
 } from 'react-native'
 
 import { EmptyCard } from './EmptyCard'
 
-type ListProps<ItemT> = Omit<FlatListProps<ItemT>, 'renderItem'>
-
-type CardListRenderItemInfo<ItemT> = ListRenderItemInfo<ItemT> & {
-  style: StyleProp<ViewStyle>
-}
-
-export type CardListProps<ItemT> = ListProps<ItemT> & {
-  renderItem: (info: CardListRenderItemInfo<ItemT>) => ReactElement | null
+export type CardListProps<ItemT> = FlatListProps<ItemT> & {
   emptyListText?: string
 }
 
@@ -35,7 +26,7 @@ export const CardList = <ItemT,>(props: CardListProps<ItemT>) => {
         [`padding${isInLeftColumn ? 'Left' : 'Right'}`]: 16,
         width: '50%'
       }
-      return renderItem({ ...info, style })
+      return <View style={style}>{renderItem?.(info)}</View>
     },
     [renderItem]
   )

--- a/src/components/core/Tile.tsx
+++ b/src/components/core/Tile.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react'
 
-import { Pressable, View, ViewStyle } from 'react-native'
+import { Pressable, StyleProp, View, ViewStyle } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 
+import { StylesProp } from 'app/styles'
 import { makeStyles } from 'app/styles/makeStyles'
 import { GestureResponderHandler } from 'app/types/gesture'
 
@@ -22,30 +23,27 @@ const useStyles = makeStyles(({ palette }) => ({
 export type TileProps = {
   children: ReactNode
   onPress?: GestureResponderHandler
-  style?: ViewStyle
-  styles?: {
+  style?: StyleProp<ViewStyle>
+  styles?: StylesProp<{
     // styles for root element
-    root?: ViewStyle
+    root: ViewStyle
     // styles for tile element, the view that establishes the border
-    tile?: ViewStyle
+    tile: ViewStyle
     // styles for the inner view that displays the tile content
-    content?: ViewStyle
-  }
+    content: ViewStyle
+  }>
 }
 
-export const Tile = ({
-  children,
-  onPress,
-  style,
-  styles: stylesProp
-}: TileProps) => {
+export const Tile = (props: TileProps) => {
+  const { children, onPress, style, styles: stylesProp } = props
   const styles = useStyles()
+
   return (
     <Shadow
-      offset={[0, 2]}
+      offset={[0, 1]}
       viewStyle={{ alignSelf: 'stretch' }}
-      distance={4}
-      startColor='rgba(133,129,153,0.05)'
+      distance={2}
+      startColor='rgba(133,129,153,0.11)'
       containerViewStyle={[style, stylesProp?.root]}
     >
       <View style={[styles.tile, stylesProp?.tile]}>

--- a/src/screens/explore-screen/tabs/ArtistsTab.tsx
+++ b/src/screens/explore-screen/tabs/ArtistsTab.tsx
@@ -51,9 +51,7 @@ export const ArtistsTab = ({ navigation }: Props) => {
       }
       contentContainerStyle={styles.contentContainer}
       data={profiles}
-      renderItem={({ item, style }) => (
-        <ArtistCard artist={item} style={style} />
-      )}
+      renderItem={({ item }) => <ArtistCard artist={item} />}
     />
   )
 }

--- a/src/screens/feed-screen/FeedScreen.tsx
+++ b/src/screens/feed-screen/FeedScreen.tsx
@@ -48,7 +48,13 @@ const FeedScreen = ({ navigation }: Props) => {
   }
 
   return (
-    <View style={{ display: 'flex', flexDirection: 'column' }}>
+    <View
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#F3F0F7'
+      }}
+    >
       <Lineup
         actions={feedActions}
         delineate

--- a/src/screens/feed-screen/FeedScreen.tsx
+++ b/src/screens/feed-screen/FeedScreen.tsx
@@ -48,13 +48,7 @@ const FeedScreen = ({ navigation }: Props) => {
   }
 
   return (
-    <View
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        backgroundColor: '#F3F0F7'
-      }}
-    >
+    <View style={{ display: 'flex', flexDirection: 'column' }}>
       <Lineup
         actions={feedActions}
         delineate


### PR DESCRIPTION
### Description

- Refactors Card component to use Tile
- Simplifies CardList impl since we wrap a View now instead of passing style through to card. This is needed cause padding directly on the card Tile messes with shadow.
- Updates tile shadow to more closely align with web client tile shadows