### PR TITLE
Add notification config for referrals-verified

### DIFF
--- a/src/components/notifications/content/ChallengeReward.tsx
+++ b/src/components/notifications/content/ChallengeReward.tsx
@@ -1,9 +1,7 @@
+import { ChallengeRewardID } from 'audius-client/src/common/models/AudioRewards'
 import { StyleSheet, Text, View } from 'react-native'
 
-import {
-  ChallengeReward as ChallengeRewardType,
-  ChallengeRewardID
-} from 'app/store/notifications/types'
+import { ChallengeReward as ChallengeRewardType } from 'app/store/notifications/types'
 import { useTheme } from 'app/utils/theme'
 
 import TwitterShare from './TwitterShare'
@@ -43,6 +41,10 @@ const challengeInfoMap: Record<
   },
   referrals: {
     title: '📨 Invite your Friends',
+    amount: 1
+  },
+  'ref-v': {
+    title: '📨 Invite your Fans',
     amount: 1
   },
   referred: {

--- a/src/store/notifications/types.ts
+++ b/src/store/notifications/types.ts
@@ -1,3 +1,4 @@
+import { ChallengeRewardID } from 'audius-client/src/common/models/AudioRewards'
 import { Collection } from 'audius-client/src/common/models/Collection'
 import { Track } from 'audius-client/src/common/models/Track'
 import { User } from 'audius-client/src/common/models/User'
@@ -157,15 +158,6 @@ export type TrendingTrack = BaseNotification & {
   entityId: ID
   entity: Track & { user: User }
 }
-
-export type ChallengeRewardID =
-  | 'track-upload'
-  | 'referrals'
-  | 'referred'
-  | 'mobile-install'
-  | 'connect-verified'
-  | 'listen-streak'
-  | 'profile-completion'
 
 export type ChallengeReward = BaseNotification & {
   type: NotificationType.ChallengeReward


### PR DESCRIPTION
### Description

Adds notification config for `ref-v` or verified referrals challenge

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested using proxy

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
